### PR TITLE
[kitsas] kirjaisin → kirjasintyyppi

### DIFF
--- a/kitupiikki/maaritys/ulkoasumaaritys.ui
+++ b/kitupiikki/maaritys/ulkoasumaaritys.ui
@@ -30,13 +30,13 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Kirjaisin</string>
+      <string>Kirjasintyyppi</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QRadioButton" name="oletusfontti">
         <property name="text">
-         <string>Järjestelmän oletuskirjaisin</string>
+         <string>Järjestelmän oletuskirjasintyyppi</string>
         </property>
         <property name="checked">
          <bool>true</bool>


### PR DESCRIPTION
Huomasin, että Kitsaan asetuksissa sana *kirjasin* oli typotettu muotoon *kirjaisin*. Tämän kirjoitusvirheen korjattuani luin kuitenkin vielä Wikipediasta, että sana *kirjasin* on hieman epämääräinen, joten vaihdoin tuon vielä tarkempaan muotoon *kirjasintyyppi*.

### [Wikipedia: Kirjasintyyppi](https://fi.wikipedia.org/wiki/Kirjasintyyppi)
>Kirjasintyyppi eli fontti (myös kirjaintyyppi tai kirjasinlaji) on yhtenäiseen asuun piirretty merkkiryhmä, joka tavallisesti koostuu kirjaimista, numeroista sekä väli- ja erikoismerkeistä.
>– –
>Termistössä esiintyy usein epävarmuutta. Toisinaan kirjasintyypistä käytetään lyhyempää nimitystä kirjasin, mikä kuitenkin tarkkaan ottaen viittaa yksittäiseen kirjakkeeseen, esimerkiksi 'A'.
