### PR TITLE
[kitsas] Yhdistystilikartta typo fix: palveluosostot → palveluostot

### DIFF
--- a/kitupiikki/tilikartat/yhdistys.json
+++ b/kitupiikki/tilikartat/yhdistys.json
@@ -2132,7 +2132,7 @@
       "numero": 4100,
       "tyyppi": "D",
       "nimi": {
-        "fi:": "Palveluosostot, varsinainen toiminta"
+        "fi:": "Palveluostot, varsinainen toiminta"
       },
       "laajuus": 1
     },

--- a/kitupiikki/tilikartat/yhdistys/tilit.json
+++ b/kitupiikki/tilikartat/yhdistys/tilit.json
@@ -1552,7 +1552,7 @@
     "numero": 4100,
     "tyyppi": "D",
     "nimi": {
-      "fi": "Palveluosostot, varsinainen toiminta"
+      "fi": "Palveluostot, varsinainen toiminta"
     },
     "laajuus": 1
   },

--- a/testit/data/init.json
+++ b/testit/data/init.json
@@ -1619,7 +1619,7 @@
         {
             "laajuus": 1,
             "nimi": {
-                "fi": "Palveluosostot, varsinainen toiminta"
+                "fi": "Palveluostot, varsinainen toiminta"
             },
             "numero": "4100",
             "tyyppi": "D"


### PR DESCRIPTION
Sama typo kuin master-Kitupiikiin puolella (PR https://github.com/artoh/kitupiikki/pull/423) on uinut myös Kitsaan JSON-tilikarttoihin.