### PR TITLE
mac OS: lisää applikaation metadataan retina-valmius

### DIFF
--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -28,5 +28,7 @@
 	<true/>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Testaamaton muutos. Muistan kuitenkin korjanneeni erään toisen monelle alustalle tarkoitetun softan mac OS -version pelkästään tällä muutoksella. Voisiko @petriaarnio testata?

Yritin kyllä kokeilla tätä Catalinalla muokkaamalla Info.plistiä suoraan asennetun applikaation sisällä, mutta käyttöjärjestelmän code signing estää muunnellun ohjelman ajamisen. Sitten kokeilin avata kitupiikki.xcodeproj:n, mutta buildi sanoo

```make: *** /Users/petri/git/kitupiikki/mac/: No such file or directory.  Stop.```

Ja oletan noita mac-kansion skriptejä silmäilemällä, että muitakin haasteita on edessä, vaikka tuon polun korjaisi. :)

Fixes https://github.com/artoh/kitupiikki/issues/456