### PR TITLE
Korkean pikselitiheyden pixmapit päälle

### DIFF
--- a/kitupiikki/main.cpp
+++ b/kitupiikki/main.cpp
@@ -91,6 +91,7 @@ int main(int argc, char *argv[])
     translator.load("fi.qm",":/aloitus/");
 
     a.installTranslator(&translator);
+    a.setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     QStringList argumentit = qApp->arguments();
 


### PR DESCRIPTION
Kuvassa vasemmalla Kitupiikki 1.4.5, oikealla Kitupiikki buildattuna tästä haarasta.

<img width="380" alt="kitupiikki-high-dpi-fix" src="https://user-images.githubusercontent.com/1095425/72671682-8b7c5080-3a56-11ea-9b80-4a21cc37f65f.png">


Fixes https://github.com/artoh/kitupiikki/issues/456