### PR TITLE
Docs: Mac-sanamuotojen viilauksia

### DIFF
--- a/docs/asennus.md
+++ b/docs/asennus.md
@@ -29,22 +29,22 @@ Kitupiikin Linux-versio toimitetaan AppImage-tiedostona, jota ei varsinaisesti e
 4. Ensimmäisellä käynnistyskerralla Kitupiikki kysyy, haluatko lisätä ohjelman käynnistysvalikkoon.
 
 
-## <span class="fa fa-apple"></span> Macintosh
+## <span class="fa fa-apple"></span> Mac
 
-Tukee OS X versiota 10.11 ja uudempia.
+Tukee OS X -versiota 10.11 (El Capitan) ja uudempia macOS-käyttöjärjestelmiä.
 
-<span class="fa fa-exclamation-triangle"> </span> macOS Mojavessa Kitupiikki toimii vain vaaleassa näkymässä.
+<span class="fa fa-exclamation-triangle"> </span> macOS 10.14 (Mojave): Kitupiikki toimii vain vaaleassa näkymässä.
 
-<span class="fa fa-exclamation-triangle"> </span> macOS Catalinassa ohjelman käyttö on erikseen sallittava: `Järjestelmän asetukset > Suojaus ja yksityisyys > Yleinen: Apin "Kitupiikki" käynnistäminen estettiin > Avaa kuitenkin`.
+<span class="fa fa-exclamation-triangle"> </span> macOS 10.15 (Catalina): Ohjelman käyttö on erikseen sallittava: `Järjestelmän asetukset > Suojaus ja yksityisyys > Yleinen: Apin "Kitupiikki" käynnistäminen estettiin > Avaa kuitenkin`.
 
 !!! note ""
-    <span class="fa fa-apple"></span> [Kitupiikki 1.4.3 macOS asennuspaketti (18 MB) ](https://github.com/petriaarnio/kitupiikki/releases/download/mac-v1.4.5/Kitupiikki-1.4.5.dmg)  
+    <span class="fa fa-apple"></span> [Kitupiikki 1.4.5 macOS asennuspaketti (18 MB) ](https://github.com/petriaarnio/kitupiikki/releases/download/mac-v1.4.5/Kitupiikki-1.4.5.dmg)
 
 1. Lataa yllä oleva asennustiedosto
 2. Avaa asennustiedosto
 3. Vedä avautuneessa ikkunasta Kitupiikin kuvake Ohjelmat (Applications) -hakemiston kuvakkeen päälle
 
-Macintosh-julkaisua ylläpitää Petri Aarnio [mac@kitupiikki.info](mailto:mac@kitupiikki.info)
+Mac-julkaisua ylläpitää Petri Aarnio [mac@kitupiikki.info](mailto:mac@kitupiikki.info)
 
 
 ## Lähdekoodi

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@
  </div>   
  <div class="karusellissa fade">
    <img src="karuselli/mac.png">
-   <div class="txt">Saatavilla Windowsille, Macintoshille ja Linuxille</div>
+   <div class="txt">Saatavilla Windowsille, Macille ja Linuxille</div>
  </div>     
 </div>
 


### PR DESCRIPTION
* Koneen nimi: Macintosh → Mac (vaihtui 1990-luvulla)
* Käyttöjärjestelmän nimi: OS X → macOS (vaihtui versiossa 10.12 Sierra)
* Latauslinkin tekstin vanhan Kitupiikki-versionumeron korjaus
* Selkeyden vuoksi käyttisversioihin sekä versionumero että nimi, aiemmin oli kumpiakin yksinään.