### PR TITLE
Salli piste aliaksena pilkulle summaa kirjatessa

### DIFF
--- a/kitsas/tools/kpeuroedit.cpp
+++ b/kitsas/tools/kpeuroedit.cpp
@@ -129,7 +129,7 @@ void KpEuroEdit::keyPressEvent(QKeyEvent *event)
     if( kursorinpaikka == text().length())
         kursorinpaikka = pilkunpaikka;
 
-    if( event->key() == Qt::Key_Comma)
+    if( event->key() == Qt::Key_Comma || event->key() == Qt::Key_Period )
     {
         int pilkunpaikka = text().indexOf(',');
         if( pilkunpaikka > -1)


### PR DESCRIPTION
Joillain näppäimistöillä numpadissä on pilkun tilalla piste. Tämä varsin yleistä englannin kielisillä näppäimistöillä. Pistettä painettaessa kursori siirretään pilkun oikealle puolelle, kuin olisit painanut pilkkua.

Eli viilataan pilkkua tässä parhaimmillaan... 😄 