### PR TITLE
Lisää MIME-tyyppi desktop-tiedostoon

### DIFF
--- a/kitsas.desktop
+++ b/kitsas.desktop
@@ -6,3 +6,4 @@ Icon=kitsas
 Comment=Avoimen lähdekoodin kirjanpitäjä
 Terminal=false
 Categories=Office;Finance;Qt;
+MimeType=application/vnd.sqlite3


### PR DESCRIPTION
Kitsas käyttää tiedostojen tallennukseen sqlite3-tietokantaa, jolloin
MIME-tyyppi on sama kuin millä tahansa sqlite3-tietokannalla. Nyt
desktop-tiedostossa on assosioitu sqlite3-tietokantatyyppi Kitsaaseen,
jolloin esimerkiksi tiedostoselain osaa tarjota Kitsasta
kirjanpitotiedostoa avatessa. Haittapuolena Kitsasta tarjotaan myös
muille sqlite3-tietokantatiedostoille. Ratkaisuna Kitsas voisi käyttää
omaa MIME-tyyppiä.

Kokeiltu Debian GNU/Linuxilla Plasma-työpöytäympäristössä.