### PR TITLE
Add English translations to kitsas_en.ts

### DIFF
--- a/kitsas/tr/kitsas_en.ts
+++ b/kitsas/tr/kitsas_en.ts
@@ -6,34 +6,36 @@
     <message>
         <location filename="../aloitussivu/aboutdialog.ui" line="14"/>
         <source>Tietoja Kitsaasta</source>
-        <translation type="unfinished"></translation>
+        <translation>About Kitsas</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aboutdialog.ui" line="37"/>
         <source>Versio</source>
-        <translation type="unfinished"></translation>
+        <translation>Version</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aboutdialog.ui" line="44"/>
         <source>Copyright © Arto Hyvättinen 2017 - 2019&lt;br/&gt;
 Copyright © Arto Hyvättinen ja Kitsas Oy 2019 - 2024&lt;br/&gt;
 &lt;a href=&quot;https://kitsas.fi&quot;&gt;kitsas.fi&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Copyright © Arto Hyvättinen 2017 - 2019&lt;br/&gt;
+Copyright © Arto Hyvättinen and Kitsas Oy 2019 - 2024&lt;br/&gt;
+&lt;a href=&quot;https://kitsas.fi&quot;&gt;kitsas.fi&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aboutdialog.ui" line="56"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ohjelmaa saa käyttää, kopioida, levittää ja muokata maksutta GNU General Public License 3:n ehtojen mukaisesti, katso tarkemmin &lt;a href=&quot;https://kitsas.fi/docs/lisenssi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;https://kitsas.fi/docs/lisenssi&lt;/span&gt;&lt;/a&gt;, jossa myös tiedot ohjelman käyttämien avoimen lähdekoodin komponenttien käyttöehdoista. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Ohjelmalla ei ole mitään takuuta!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The program can be used, copied, distributed and modified free of charge under the terms of GNU General Public License 3, see more details at &lt;a href=&quot;https://kitsas.fi/docs/lisenssi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;https://kitsas.fi/docs/lisenssi&lt;/span&gt;&lt;/a&gt;, which also contains information about the terms of use of the open source components used by the program. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The program comes with no warranty!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aboutdialog.ui" line="84"/>
         <source>&amp;Tietoja Qt:sta</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;About Qt</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aboutdialog.ui" line="111"/>
         <source>&amp;OK</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;OK</translation>
     </message>
 </context>
 <context>
@@ -41,152 +43,152 @@ Copyright © Arto Hyvättinen ja Kitsas Oy 2019 - 2024&lt;br/&gt;
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="14"/>
         <source>Kirjanpitoaineiston muodostaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Generating accounting material</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="20"/>
         <source>Toiminto muodostaa koko tilikaudesta yhden ison pdf-tiedoston. Tiedoston muodostaminen saattaa epäonnistua, jos tietokoneessa ei ole riittävästi muistia ja kirjanpidossa on paljon tositteita.</source>
-        <translation type="unfinished"></translation>
+        <translation>This function creates one large PDF file for the entire accounting period. The file creation may fail if the computer does not have enough memory and there are many vouchers in the accounting.</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="39"/>
         <source>Tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="52"/>
         <source>Tiedostonnimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Filename</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="71"/>
         <source>Vaihda</source>
-        <translation type="unfinished"></translation>
+        <translation>Change</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="84"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="103"/>
         <source>Raportit</source>
-        <translation type="unfinished"></translation>
+        <translation>Reports</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="112"/>
         <source>Tase</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="122"/>
         <source>Tuloslaskelma</source>
-        <translation type="unfinished"></translation>
+        <translation>Income statement</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="132"/>
         <source>Tase-erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet specification</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="142"/>
         <source>Päiväkirja</source>
-        <translation type="unfinished"></translation>
+        <translation>Journal</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="152"/>
         <source>Pääkirja</source>
-        <translation type="unfinished"></translation>
+        <translation>General ledger</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="162"/>
         <source>Avoimet myyntilaskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Open Sales Invoices</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="172"/>
         <source>Avoimet ostolaskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Open Purchase Invoices</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="182"/>
         <source>Tositeluettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Document list</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="215"/>
         <source>Tililuettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="224"/>
         <source>Kaikki tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>All accounts</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="231"/>
         <source>Tilikartan laajuuden mukaan</source>
-        <translation type="unfinished"></translation>
+        <translation>According to the scope of the chart of accounts</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="241"/>
         <source>Tilit joilla kirjauksia</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounts with entries</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="251"/>
         <source>Tositteiden tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher details</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="260"/>
         <source>Muistiinpanot</source>
-        <translation type="unfinished"></translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="270"/>
         <source>Täydet tiliöinnit</source>
-        <translation type="unfinished"></translation>
+        <translation>Full account entries</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="277"/>
         <source>Kaikkien tositteiden tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Details of all vouchers</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="287"/>
         <source>Liitteet</source>
-        <translation type="unfinished"></translation>
+        <translation>Attachments</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.ui" line="296"/>
         <source>Kuvanlaatu</source>
-        <translation type="unfinished"></translation>
+        <translation>Image Quality</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.cpp" line="87"/>
         <source>Peruuta</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.cpp" line="87"/>
         <source>Muodostetaan aineistoa. Tämä voi kestää useamman minuutin.</source>
-        <translation type="unfinished"></translation>
+        <translation>Generating data. This may take several minutes.</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.cpp" line="178"/>
         <source>Tallenna aineisto tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Save data to file</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.cpp" line="179"/>
         <source>Pdf-tiedosto (*.pdf)</source>
-        <translation type="unfinished"></translation>
+        <translation>PDF file (*.pdf)</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.cpp" line="499"/>
         <source>Virhe aineiston muodostamisessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Error in generating data</translation>
     </message>
     <message>
         <location filename="../arkistoija/aineistodialog.cpp" line="500"/>
@@ -195,7 +197,11 @@ Copyright © Arto Hyvättinen ja Kitsas Oy 2019 - 2024&lt;br/&gt;
 Todennäköisesti liitetiedostojen koko yhteensä on liian suuri, jotta ohjelma pystyisi muodostamaan niistä kaikista yhden pdf-tiedoston.
 
 Voit kuitenkin käyttää Arkisto-toimintoa muodostaaksesi kirjanpidostasi arkiston.</source>
-        <translation type="unfinished"></translation>
+        <translation>An error occurred while generating the data from vouchers.
+
+The total size of the attachments is likely too large for the program to create a single PDF file from all of them.
+
+However, you can use the Archive function to create an archive of your accounting.</translation>
     </message>
 </context>
 <context>
@@ -203,92 +209,92 @@ Voit kuitenkin käyttää Arkisto-toimintoa muodostaaksesi kirjanpidostasi arkis
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="25"/>
         <source>Alennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Discount</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="27"/>
         <source>Kiinteänpituinen kausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Fixed-length period</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="28"/>
         <source>Tilapäinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Temporary</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="29"/>
         <source>Vakio</source>
-        <translation type="unfinished"></translation>
+        <translation>Standard</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="30"/>
         <source>Vuosittainen myynti</source>
-        <translation type="unfinished"></translation>
+        <translation>Annual sales</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="31"/>
         <source>Hyvitys aikataulua edellä olevasta työstä</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit for work ahead of schedule</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="35"/>
         <source>Työonnettomuus</source>
-        <translation type="unfinished"></translation>
+        <translation>Work accident</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="43"/>
         <source>Materiaalin ylijäämä/vähentäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Material surplus/reduction</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="32"/>
         <source>Muu hyvitys</source>
-        <translation type="unfinished"></translation>
+        <translation>Other credit</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="33"/>
         <source>Valmistajan kuluttaja-alennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Manufacturer&apos;s consumer discount</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="34"/>
         <source>Asiakkaan sotilaallinen asema</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer&apos;s military status</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="36"/>
         <source>Erikoissopimus</source>
-        <translation type="unfinished"></translation>
+        <translation>Special agreement</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="37"/>
         <source>Alennus tuotantovirheestä</source>
-        <translation type="unfinished"></translation>
+        <translation>Discount for production error</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="38"/>
         <source>Uuden markkinan alennus</source>
-        <translation type="unfinished"></translation>
+        <translation>New market discount</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="39"/>
         <source>Näytealennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Sample discount</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="40"/>
         <source>Loppuerän alennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Final batch discount</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="41"/>
         <source>Toimituslausekealennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivery term discount</translation>
     </message>
     <message>
         <location filename="../laskutus/alennustyyppimodel.cpp" line="42"/>
         <source>Myyntikynnysalennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Sales threshold discount</translation>
     </message>
 </context>
 <context>
@@ -296,24 +302,26 @@ Voit kuitenkin käyttää Arkisto-toimintoa muodostaaksesi kirjanpidostasi arkis
     <message>
         <location filename="../maaritys/extra/aliasdialog.ui" line="14"/>
         <source>Kirjanpidon alias</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting alias</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/aliasdialog.ui" line="20"/>
         <source>Voit määrittää kirjanpidolle nimen tai lyhenteen, jolla kirjanpitoon viitataan lisäpalveluissa esimerkiksi aineistoa tuotaessa.
 
 Aliaksen tulee olla 3-32 merkkiä pitkä, alkaa kirjaimella, ja sisältää vain kirjaimia A-Z sekä numeroita.</source>
-        <translation type="unfinished"></translation>
+        <translation>You can specify a name or abbreviation for the accounting, which is used to refer to the accounting in additional services, for example when importing data.
+
+The alias must be 3-32 characters long, start with a letter, and contain only letters A-Z and numbers.</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/aliasdialog.ui" line="38"/>
         <source>Alias on jo käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Alias is already in use</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/aliasdialog.ui" line="48"/>
         <source>Alias on käytettävissä</source>
-        <translation type="unfinished"></translation>
+        <translation>Alias is available</translation>
     </message>
 </context>
 <context>
@@ -321,207 +329,208 @@ Aliaksen tulee olla 3-32 merkkiä pitkä, alkaa kirjaimella, ja sisältää vain
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="60"/>
         <source>Tervetuloa</source>
-        <translation type="unfinished"></translation>
+        <translation>Welcome</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="83"/>
         <source>Kirjanpito on tallennettu omalle tietokoneellesi.</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting has been saved on your own computer.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="96"/>
         <source>Kirjanpito on tallennettu Kitsaan pilveen.</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting has been saved to Kitsas cloud.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="141"/>
         <source>Käsiteltäviä tositteita työjonossa</source>
-        <translation type="unfinished"></translation>
+        <translation>Vouchers to be processed in the work queue</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="165"/>
         <location filename="../aloitussivu/aloitus.ui" line="202"/>
         <location filename="../aloitussivu/aloitus.ui" line="247"/>
         <source>0</source>
-        <translation type="unfinished"></translation>
+        <translation>0</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="199"/>
         <source>Lähetettäviä laskuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoices to be sent</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="212"/>
         <source>Tiliöimättömiä tositteita</source>
-        <translation type="unfinished"></translation>
+        <translation>Unaccounted vouchers</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="312"/>
         <source>Tietokone</source>
-        <translation type="unfinished"></translation>
+        <translation>Computer</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="318"/>
         <source>Avaa kirjanpitotiedosto    Ctrl + O</source>
-        <translation type="unfinished"></translation>
+        <translation>Open accounting file    Ctrl + O</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="321"/>
         <source>Avaa kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Open accounting</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="328"/>
         <source>Ctrl+O</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+O</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="348"/>
         <source>Tuo Kitupiikistä</source>
-        <translation type="unfinished"></translation>
+        <translation>Import from Kitupiikki</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="362"/>
         <source>Varmuuskopioi</source>
-        <translation type="unfinished"></translation>
+        <translation>Backup</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="376"/>
         <source>Poista luettelosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove from list</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="392"/>
         <source>Pilvi</source>
-        <translation type="unfinished"></translation>
+        <translation>Cloud</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="405"/>
         <location filename="../aloitussivu/aloitus.ui" line="485"/>
         <source>Kirjaudu</source>
-        <translation type="unfinished"></translation>
+        <translation>Log in</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="415"/>
         <source>Palvelin ei juuri nyt ole käytettävissä. Yritä myöhemmin uudestaan. </source>
-        <translation type="unfinished"></translation>
+        <translation>The server is not available right now. Please try again later. </translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="428"/>
         <source>Salasana on virheellinen</source>
-        <translation type="unfinished"></translation>
+        <translation>The password is incorrect</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="435"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="445"/>
         <source>Kirjoita ensin osoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Write the address first</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="452"/>
         <source>Salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="475"/>
         <source>Muista minut</source>
-        <translation type="unfinished"></translation>
+        <translation>Remember me</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="505"/>
         <source>Unohdin salasanan</source>
-        <translation type="unfinished"></translation>
+        <translation>Forgot password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="519"/>
         <source>Uusi käyttäjä</source>
-        <translation type="unfinished"></translation>
+        <translation>New user</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="525"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tarjoamme uudelle käyttäjälle 30 päivän maksuttoman kokeilujakson Kitsaan pilviominaisuuksiin.&lt;/p&gt;
 &lt;p&gt;Lue enemmän &lt;a href=&quot;https://kitsas.fi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;kitsas.fi&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;We offer a 30-day free trial of Kitsas cloud features for new users.&lt;/p&gt;
+&lt;p&gt;Read more at &lt;a href=&quot;https://kitsas.fi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;kitsas.fi&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="542"/>
         <source>Luo käyttäjätunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Create user account</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="573"/>
         <location filename="../aloitussivu/aloitus.ui" line="583"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="593"/>
         <source>Kirjaudu ulos</source>
-        <translation type="unfinished"></translation>
+        <translation>Log out</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="604"/>
         <source>Vaihda salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Change password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="615"/>
         <source>Tee tilaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Make an order</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="641"/>
         <source>Etsi kirjanpitoa...</source>
-        <translation type="unfinished"></translation>
+        <translation>Search accounting...</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="666"/>
         <source>Poista kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete accounting</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="677"/>
         <source>Kopioi kirjanpito pilveen</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy accounting to cloud</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="705"/>
         <source>Kirjaudutaan palvelimelle...</source>
-        <translation type="unfinished"></translation>
+        <translation>Logging in to server...</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="737"/>
         <source>Tuki</source>
-        <translation type="unfinished"></translation>
+        <translation>Support</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="750"/>
         <source>Aloita uusi kirjanpito   Ctrl+N</source>
-        <translation type="unfinished"></translation>
+        <translation>Start new accounting   Ctrl+N</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="753"/>
         <source>Uusi kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>New accounting</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="767"/>
         <source>Muistiinpanot</source>
-        <translation type="unfinished"></translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitus.ui" line="778"/>
         <source>Tietoja</source>
-        <translation type="unfinished"></translation>
+        <translation>About</translation>
     </message>
 </context>
 <context>
@@ -529,112 +538,112 @@ Aliaksen tulee olla 3-32 merkkiä pitkä, alkaa kirjaimella, ja sisältää vain
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="69"/>
         <source>Avataan kirjanpitoa...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../aloitussivu/aloitusbrowser.cpp" line="125"/>
-        <source>Testauspalvelin käytössä</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../aloitussivu/aloitusbrowser.cpp" line="125"/>
-        <source>Käytä vain kehitys- ja testauskäytössä!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../aloitussivu/aloitusbrowser.cpp" line="128"/>
-        <source>Kehitysversio käytössä</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../aloitussivu/aloitusbrowser.cpp" line="128"/>
-        <source>Käytössäsi on Kitsaan kehitysversio, jota ei välttämättä ole vielä testattu kattavasti.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../aloitussivu/aloitusbrowser.cpp" line="135"/>
-        <source>Tiliöinti on kesken %1 tositteessa.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../aloitussivu/aloitusbrowser.cpp" line="136"/>
-        <source>Tositteissa on kirjaamattomia vientejä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening accounting...</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="115"/>
         <source>Kirjanpito ei ole käytettävissä</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting is unavailable</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="116"/>
         <source>Sinulla ei ole kirjanpidon avaamiseen tarvittavia oikeuksia tai kirjanpidon omistajan käyttöoikeus ei ole voimassa.</source>
-        <translation type="unfinished"></translation>
+        <translation>You do not have the necessary rights to open the accounting or the accounting owner&apos;s access rights are not valid.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="117"/>
         <source>Ole tarvittaessa yhteydessä Kitsaan Helpdeskiin.</source>
-        <translation type="unfinished"></translation>
+        <translation>If needed, contact Kitsas Helpdesk.</translation>
+    </message>
+    <message>
+        <location filename="../aloitussivu/aloitusbrowser.cpp" line="125"/>
+        <source>Testauspalvelin käytössä</source>
+        <translation>Test server in use</translation>
+    </message>
+    <message>
+        <location filename="../aloitussivu/aloitusbrowser.cpp" line="125"/>
+        <source>Käytä vain kehitys- ja testauskäytössä!</source>
+        <translation>Use only for development and testing purposes!</translation>
+    </message>
+    <message>
+        <location filename="../aloitussivu/aloitusbrowser.cpp" line="128"/>
+        <source>Kehitysversio käytössä</source>
+        <translation>Development version in use</translation>
+    </message>
+    <message>
+        <location filename="../aloitussivu/aloitusbrowser.cpp" line="128"/>
+        <source>Käytössäsi on Kitsaan kehitysversio, jota ei välttämättä ole vielä testattu kattavasti.</source>
+        <translation>You are using a development version of Kitsas, which may not have been thoroughly tested yet.</translation>
+    </message>
+    <message>
+        <location filename="../aloitussivu/aloitusbrowser.cpp" line="135"/>
+        <source>Tiliöinti on kesken %1 tositteessa.</source>
+        <translation>Accounting is incomplete in %1 voucher(s).</translation>
+    </message>
+    <message>
+        <location filename="../aloitussivu/aloitusbrowser.cpp" line="136"/>
+        <source>Tositteissa on kirjaamattomia vientejä.</source>
+        <translation>There are unrecorded entries in the vouchers.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="149"/>
         <source>Varmuuskopio käytössä?</source>
-        <translation type="unfinished"></translation>
+        <translation>Backup in use?</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="150"/>
         <source>Tämä tiedosto on todennäköisesti kirjanpitosi varmuuskopio päivämäärällä %1&lt;br&gt;Tähän tiedostoon tehdyt muutokset eivät tallennu varsinaiseen kirjanpitoosi.</source>
-        <translation type="unfinished"></translation>
+        <translation>This file is likely a backup of your accounting dated %1&lt;br&gt;Changes made to this file will not be saved to your actual accounting.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="155"/>
         <source>Paikallinen kirjanpito käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Local accounting in use</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="156"/>
         <source>Käytössäsi on omalle tietokoneellesi tallennettu kirjanpito. Muutokset eivät tallennu Kitsaan pilveen.&lt;/p&gt;&lt;p&gt;Pilvessä olevan kirjanpitosi voit avata Pilvi-välilehdeltä.</source>
-        <translation type="unfinished"></translation>
+        <translation>You are using accounting saved on your own computer. Changes will not be saved to the Kitsas cloud.&lt;/p&gt;&lt;p&gt;You can open your cloud-based accounting from the Cloud tab.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="160"/>
         <source>Muista varmuuskopiointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Remember backups</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="161"/>
         <source>Kirjanpito on tallennettu omalle tietokoneellesi.</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting has been saved on your own computer.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="161"/>
         <source>Muista tehdä säännöllisesti varmuuskopioita ja säilyttää niitä turvallisessa paikassa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Remember to make regular backups and store them in a safe place.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="170"/>
         <source>Tilaus on tarkoitettu arvonlisäverottomaan toimintaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>The subscription is intended for non-VAT activities.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="171"/>
         <source>Pilvikirjanpidon omistajalla on tilaus, jota ei ole tarkoitettu arvonlisäverolliseen toimintaan. Arvonlisäilmoitukseen liittyviä toimintoja ei siksi ole käytössä tälle kirjanpidolle.</source>
-        <translation type="unfinished"></translation>
+        <translation>The cloud accounting owner has a subscription that is not intended for VAT-liable activities. Therefore, functions related to VAT reporting are not available for this accounting.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="183"/>
         <source>Päivitä tilikartta</source>
-        <translation type="unfinished"></translation>
+        <translation>Update chart of accounts</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="184"/>
         <source>Tilikartasta saatavilla uudempi versio %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>A newer version of the chart of accounts is available %1.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="197"/>
         <source>Tarkista perusvalinnat ja arvonlisäverovelvollisuus</source>
-        <translation type="unfinished"></translation>
+        <translation>Check basic settings and VAT liability</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="197"/>
@@ -643,128 +652,128 @@ Aliaksen tulee olla 3-32 merkkiä pitkä, alkaa kirjaimella, ja sisältää vain
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="200"/>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="203"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="198"/>
         <source>Tarkista yhteystiedot ja logo</source>
-        <translation type="unfinished"></translation>
+        <translation>Check contact information and logo</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="199"/>
         <source>Tutustu tilikarttaan ja tee tarpeelliset muutokset</source>
-        <translation type="unfinished"></translation>
+        <translation>Familiarize yourself with the chart of accounts and make necessary changes</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="200"/>
         <source>Lisää tarvitsemasi kohdennukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Add the allocations you need</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="202"/>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="211"/>
         <source>Tee tilinavaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Make an account opening</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="203"/>
         <source>Voit aloittaa kirjausten tekemisen</source>
-        <translation type="unfinished"></translation>
+        <translation>You can start making entries</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="205"/>
         <source>Kirjanpidon aloittaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Starting the accounting</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="212"/>
         <source>Syötä viimeisimmältä tilinpäätökseltä tilien avaavat saldot %1 järjestelmään.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter the opening balances from the latest financial statement %1 into the system.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="273"/>
         <source>Arvonlisäveroilmoitus myöhässä</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT return is late</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="274"/>
         <source>Arvonlisäveroilmoitus kaudelta %1 - %2 olisi pitänyt antaa %3 mennessä.</source>
-        <translation type="unfinished"></translation>
+        <translation>The VAT return for the period %1 - %2 should have been submitted by %3.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="280"/>
         <source>Tee arvonlisäverotilitys</source>
-        <translation type="unfinished"></translation>
+        <translation>Make a VAT settlement</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="281"/>
         <source>Arvonlisäveroilmoitus kaudelta %1 - %2 on annettava %3 mennessä.</source>
-        <translation type="unfinished"></translation>
+        <translation>The VAT return for the period %1 - %2 must be submitted by %3.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="293"/>
         <source>Aloita uusi tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Start a new financial year</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="294"/>
         <source>Tilikausi päättyy %1, jonka jälkeiselle ajalle ei voi tehdä kirjauksia ennen kuin uusi tilikausi aloitetaan.&lt;/p&gt;&lt;p&gt;Voit tehdä kirjauksia myös aiempaan tilikauteen, kunnes se on päätetty.</source>
-        <translation type="unfinished"></translation>
+        <translation>The financial year ends on %1, after which entries cannot be made until a new financial year is started.&lt;/p&gt;&lt;p&gt;You can also make entries for the previous financial year until it is closed.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="313"/>
         <source>Aika laatia tilinpäätös tilikaudelle %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Time to prepare financial statements for the financial year %1</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="315"/>
         <source>Tee loppuun kaikki tilikaudelle kuuluvat kirjaukset ja laadi sen jälkeen tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>Complete all entries for the financial year and then prepare the financial statements</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="316"/>
         <source>Viimeistele ja vahvista tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalize and confirm the financial statements</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="387"/>
         <source>Tase ei täsmää</source>
-        <translation type="unfinished"></translation>
+        <translation>The balance sheet doesn&apos;t match</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="390"/>
         <source>Kirjanpidon debet- ja kredit-kirjaukset eivät täsmää. Tase ei ole tasapainossa.</source>
-        <translation type="unfinished"></translation>
+        <translation>The debit and credit entries in the accounting don&apos;t match. The balance sheet is not balanced.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="391"/>
         <source>Tämä on vakava virhe ja tarkoittaa aina, ettei kirjanpito ole kunnossa!</source>
-        <translation type="unfinished"></translation>
+        <translation>This is a serious error and always means that the accounting is not in order!</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="397"/>
         <source>&lt;p&gt;&lt;h2 class=kausi&gt;Tilikausi %1 - %2 &lt;/h1&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;&lt;h2 class=kausi&gt;Financial year %1 - %2 &lt;/h1&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="421"/>
         <source>Vastaavaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Assets</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="423"/>
         <source>Vastattavaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Liabilities</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="425"/>
         <source>Tuloslaskelma</source>
-        <translation type="unfinished"></translation>
+        <translation>Income statement</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusbrowser.cpp" line="436"/>
         <source>Tilikauden tulos</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial year result</translation>
     </message>
 </context>
 <context>
@@ -772,97 +781,100 @@ Aliaksen tulee olla 3-32 merkkiä pitkä, alkaa kirjaimella, ja sisältää vain
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="371"/>
         <source>Varmuuskopioi kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Backup accounting</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="371"/>
         <source>Kirjanpito (*.kitsas)</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting (*.kitsas)</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="376"/>
         <location filename="../aloitussivu/aloitussivu.cpp" line="390"/>
         <source>Virhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="376"/>
         <source>Tiedostoa ei saa kopioida itsensä päälle!</source>
-        <translation type="unfinished"></translation>
+        <translation>The file cannot be copied over itself!</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="387"/>
         <source>Kirjanpidon varmuuskopiointi onnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting backup was successful.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="390"/>
         <source>Tiedoston varmuuskopiointi epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>File backup failed.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="418"/>
         <source>Poista kirjanpito luettelosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove accounting from the list</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="419"/>
         <source>Haluatko poistaa tämän kirjanpidon viimeisten kirjanpitojen luettelosta?
 Kirjanpitoa ei poisteta levyltä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to remove this accounting from the list of recent accounts?
+The accounting will not be deleted from the disk.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="430"/>
         <location filename="../aloitussivu/aloitussivu.cpp" line="437"/>
         <source>Kirjanpidon poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete accounting</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="431"/>
         <source>Turvallisuussyistä voit poistaa vain harjoittelutilassa olevan kirjanpidon.
 
 Poistaaksesi tämän kirjanpidon sinun pitää ensin asettaa Asetukset/Perusvalinnat-sivulla määritys Harjoituskirjanpito.</source>
-        <translation type="unfinished"></translation>
+        <translation>For security reasons, you can only delete accounting in practice mode.
+
+To delete this accounting, you must first set the Practice Accounting configuration on the Settings/Basic Options page.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="438"/>
         <source>Haluatko todella poistaa tämän kirjanpidon %1 pysyvästi?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to permanently delete this accounting %1?</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="495"/>
         <source>Käyttö estetty maksamattomien tilausmaksujen takia</source>
-        <translation type="unfinished"></translation>
+        <translation>Access blocked due to unpaid subscription fees</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="498"/>
         <source>Käyttö estetty käyttösääntöjen vastaisen toiminnan takia</source>
-        <translation type="unfinished"></translation>
+        <translation>Access blocked due to activity violating terms of use</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="501"/>
         <source>Käyttäjätunnus suljettu tilapäisesti käyttäjän pyynnöstä</source>
-        <translation type="unfinished"></translation>
+        <translation>User account temporarily closed at user&apos;s request</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="504"/>
         <source>Käyttäjätunnus suljettu</source>
-        <translation type="unfinished"></translation>
+        <translation>User account closed</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="510"/>
         <source>Kokeilujakso %1 saakka</source>
-        <translation type="unfinished"></translation>
+        <translation>Trial period until %1</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="522"/>
         <source>Tilaukseni</source>
-        <translation type="unfinished"></translation>
+        <translation>My subscription</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitussivu.cpp" line="522"/>
         <source>Tee tilaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Make an order</translation>
     </message>
 </context>
 <context>
@@ -870,128 +882,129 @@ Poistaaksesi tämän kirjanpidon sinun pitää ensin asettaa Asetukset/Perusvali
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="26"/>
         <source>Arvonlisäveroilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Value Added Tax (VAT) declaration</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="32"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kaikki arvonlisäverolliset kirjaukset pitää tehdä ennen alv-ilmoituksen antamista.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;All VAT-related entries must be made before submitting the VAT return.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="45"/>
         <source>Kirjaa alarajahuojennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Record VAT relief for small businesses</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="54"/>
         <source>&lt;b&gt;Tarkasta laskelma alarajahuojennuksesta!&lt;/b&gt; Mikäli liikevaihtoon sisältyy esimerksi metsätalouden, kiinteistön käyttöoikeuden tai käyttöomaisuuden myynnin tuloa, joudut korjaamaan laskennan perusteena olevia määriä.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Check the calculation for VAT relief!&lt;/b&gt; If the turnover includes income from forestry, real estate usage rights, or sale of fixed assets, for example, you will need to adjust the amounts used as the basis for the calculation.</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="66"/>
         <source>Alarajahuojennukseen oikeuttava liikevaihto</source>
-        <translation type="unfinished"></translation>
+        <translation>Turnover eligible for VAT relief</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="79"/>
         <source>Alarajahuojennukseen oikeuttava vero</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax eligible for VAT relief</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="92"/>
         <source>Alarajahuojennuksen määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount of VAT relief</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="114"/>
         <source>Lähetä alv-ilmoitus verottajalle</source>
-        <translation type="unfinished"></translation>
+        <translation>Send VAT return to tax authorities</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="123"/>
         <source>Yhteyshenkilön nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact person&apos;s name</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="140"/>
         <source>Puhelinnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="157"/>
         <source>Korjauksen syy</source>
-        <translation type="unfinished"></translation>
+        <translation>Reason for correction</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.ui" line="170"/>
         <source>Sähköisen ilmoittamisen rajapinta ei ole käytössä. Tee itse ilmoitus verottajalle OmaVero-palvelussa.</source>
-        <translation type="unfinished"></translation>
+        <translation>The electronic reporting interface is not available. Submit the report yourself to the tax authorities through the OmaVero service.</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="58"/>
         <source>Laskuvirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Calculation error</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="59"/>
         <source>Oikeuskäytännön muutos</source>
-        <translation type="unfinished"></translation>
+        <translation>Change in legal practice</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="60"/>
         <source>Verotarkastuksessa saatu ohjaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Guidance received during tax audit</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="61"/>
         <source>Laintulkintavirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Error in law interpretation</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="142"/>
         <source>Ei oikeuta alarajahuojennukseen</source>
-        <translation type="unfinished"></translation>
+        <translation>Not eligible for small business relief</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="150"/>
         <source>Virhe ilmoittamisessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Error in reporting</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="151"/>
         <source>Alv-ilmoituksen toimittaminen verottajalle epäonnistui.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to submit VAT return to tax authorities.
+</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="168"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="198"/>
         <source>Arvonlisäverolaskelma tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT calculation saved</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="199"/>
         <source>Et valinnut ilmoittamista verottajalle rajapinnan kautta</source>
-        <translation type="unfinished"></translation>
+        <translation>You did not choose to report to the tax authorities through the interface</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="200"/>
         <source>Huolehdi ilmoittamisesta verottajalle esimerkiksi OmaVerossa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Make sure to report to the tax authorities, for example through OmaVero.</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="202"/>
         <source>Arvonlisäveroilmoitus annettu</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT return submitted</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitusdialog.cpp" line="204"/>
         <source>Arvonlisäverolaskelma tallennettu.</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT calculation saved.</translation>
     </message>
 </context>
 <context>
@@ -999,32 +1012,32 @@ Poistaaksesi tämän kirjanpidon sinun pitää ensin asettaa Asetukset/Perusvali
     <message>
         <location filename="../alv/alvilmoitustenmodel.cpp" line="57"/>
         <source>Alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Starts</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitustenmodel.cpp" line="59"/>
         <source>Päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>Ends</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitustenmodel.cpp" line="61"/>
         <source>Eräpäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Due date</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitustenmodel.cpp" line="63"/>
         <source>Maksettava vero</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax payable</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitustenmodel.cpp" line="65"/>
         <source>Ilmoituksen tila</source>
-        <translation type="unfinished"></translation>
+        <translation>Report status</translation>
     </message>
     <message>
         <location filename="../alv/alvilmoitustenmodel.cpp" line="95"/>
         <source>Ilmoitettu %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Reported %1</translation>
     </message>
 </context>
 <context>
@@ -1032,27 +1045,27 @@ Poistaaksesi tämän kirjanpidon sinun pitää ensin asettaa Asetukset/Perusvali
     <message>
         <location filename="../alv/alvkaudet.cpp" line="124"/>
         <source>Käsitelty</source>
-        <translation type="unfinished"></translation>
+        <translation>Processed</translation>
     </message>
     <message>
         <location filename="../alv/alvkaudet.cpp" line="125"/>
         <source>Käsittelyssä</source>
-        <translation type="unfinished"></translation>
+        <translation>In process</translation>
     </message>
     <message>
         <location filename="../alv/alvkaudet.cpp" line="126"/>
         <source>Ilmoitus puuttuu</source>
-        <translation type="unfinished"></translation>
+        <translation>Notification missing</translation>
     </message>
     <message>
         <location filename="../alv/alvkaudet.cpp" line="127"/>
         <source>Arvioitu</source>
-        <translation type="unfinished"></translation>
+        <translation>Estimated</translation>
     </message>
     <message>
         <location filename="../alv/alvkaudet.cpp" line="128"/>
         <source>Erääntynyt</source>
-        <translation type="unfinished"></translation>
+        <translation>Overdue</translation>
     </message>
 </context>
 <context>
@@ -1060,7 +1073,7 @@ Poistaaksesi tämän kirjanpidon sinun pitää ensin asettaa Asetukset/Perusvali
     <message>
         <location filename="../alv/alvlaskelma.cpp" line="546"/>
         <source>Vanhentunut maksuperusteinen alv %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Overdue cash-basis VAT %1</translation>
     </message>
 </context>
 <context>
@@ -1068,108 +1081,109 @@ Poistaaksesi tämän kirjanpidon sinun pitää ensin asettaa Asetukset/Perusvali
     <message>
         <location filename="../alv/arvonlisavero.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="44"/>
         <source>Alv-ilmoitus alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT return starts</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="86"/>
         <source>xxx</source>
-        <translation type="unfinished"></translation>
+        <translation>xxx</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="76"/>
         <source>Eräpäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Due date</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="22"/>
         <source>Uusi ALV-ilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>New VAT return</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="30"/>
         <source>Alv-kausi</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT period</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="58"/>
         <source>Alv-ilmoitus päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT return ends</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="95"/>
         <source>&amp;Tee alv-ilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;File VAT return</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="102"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="112"/>
         <source>Yhteenvetoilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Summary declaration</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="128"/>
         <source>Tee &amp;yhteenvetoilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>File &amp;summary declaration</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="144"/>
         <source>Annetut ALV-ilmoitukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Submitted VAT returns</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="168"/>
         <source>&amp;Näytä tilitys</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Show settlement</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="175"/>
         <source>F9</source>
-        <translation type="unfinished"></translation>
+        <translation>F9</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="185"/>
         <source>Poista tilitys</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove settlement</translation>
     </message>
     <message>
         <location filename="../alv/arvonlisavero.ui" line="212"/>
         <source>Ilmoitinaineisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Reporting material</translation>
     </message>
     <message>
         <location filename="../alv/alvsivu.cpp" line="155"/>
         <source>Alv-ilmoituksen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Deleting VAT declaration</translation>
     </message>
     <message>
         <location filename="../alv/alvsivu.cpp" line="155"/>
         <source>Haluatko todellakin poistaa valitun alv-ilmoituksen?
 Poistamisen jälkeen sinun on laadittava uusi alv-ilmoitus.</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to delete the selected VAT declaration?
+After deletion, you must create a new VAT declaration.</translation>
     </message>
     <message>
         <location filename="../alv/alvsivu.cpp" line="273"/>
         <source>Yhteenvetoilmoitus edelliseltä kuukaudelta on annettu</source>
-        <translation type="unfinished"></translation>
+        <translation>The summary declaration for the previous month has been submitted</translation>
     </message>
     <message>
         <location filename="../alv/alvsivu.cpp" line="283"/>
         <source>Kitsas ei voi muodostaa ilmoitusta, koska kaikkien yhteisömyynnin asiakkaiden ALV-tunnuksia ei ole syötetty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas cannot generate the declaration because VAT numbers for all intra-community sales customers have not been entered.</translation>
     </message>
     <message>
         <location filename="../alv/alvsivu.cpp" line="286"/>
         <source>Anna yhteenvetoilmoitus edelliseltä kuukaudelta 20. päivään mennessä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Submit the summary declaration for the previous month by the 20th day.</translation>
     </message>
 </context>
 <context>
@@ -1177,17 +1191,17 @@ Poistamisen jälkeen sinun on laadittava uusi alv-ilmoitus.</source>
     <message>
         <location filename="../apuri/apuririvit.cpp" line="41"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../apuri/apuririvit.cpp" line="43"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../apuri/apuririvit.cpp" line="45"/>
         <source>€</source>
-        <translation type="unfinished"></translation>
+        <translation>€</translation>
     </message>
 </context>
 <context>
@@ -1195,82 +1209,85 @@ Poistamisen jälkeen sinun on laadittava uusi alv-ilmoitus.</source>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="189"/>
         <source>Arkiston viennissä virhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Error in archive export</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="190"/>
         <source>Arkiston vienti epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Archive export failed.</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="211"/>
         <source>Kirjanpito virheellinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting is incorrect</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="212"/>
         <source>Tase ei täsmää.
 Tilinpäätöstä ei voi tehdä ennen kuin virhe on korjattu.</source>
-        <translation type="unfinished"></translation>
+        <translation>The balance sheet does not match.
+Financial statements cannot be prepared until the error is corrected.</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="307"/>
         <source>Vie arkisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Export archive</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="307"/>
         <source>Zip-arkisto (*.zip)</source>
-        <translation type="unfinished"></translation>
+        <translation>Zip archive (*.zip)</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="318"/>
         <location filename="../arkisto/arkistosivu.cpp" line="373"/>
         <source>Kopioidaan arkistoa</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying archive</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="318"/>
         <location filename="../arkisto/arkistosivu.cpp" line="373"/>
         <source>Peruuta</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="340"/>
         <source>Arkiston vienti valmis</source>
-        <translation type="unfinished"></translation>
+        <translation>Archive export complete</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="341"/>
         <source>Arkisto viety tiedostoon %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Archive exported to file %1</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="361"/>
         <source>Valitse hakemisto, jonne arkisto kopioidaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Select the directory where the archive will be copied</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="381"/>
         <source>Kopiointi ei onnistu</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying failed</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="381"/>
         <source>Tiedoston %1 kopiointi ei onnistunut.
  Kopiointi on keskeytetty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying file %1 failed.
+ The copying process has been interrupted.</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="387"/>
         <source>Arkiston kopiointi valmis</source>
-        <translation type="unfinished"></translation>
+        <translation>Archive copying complete</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistosivu.cpp" line="387"/>
         <source>Arkisto on kopioitu hakemistoon %1.
 Avaa selaimella hakemistossa oleva index.html-tiedosto.</source>
-        <translation type="unfinished"></translation>
+        <translation>The archive has been copied to directory %1.
+Open the index.html file in the directory with a browser.</translation>
     </message>
 </context>
 <context>
@@ -1278,44 +1295,46 @@ Avaa selaimella hakemistossa oleva index.html-tiedosto.</source>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.ui" line="14"/>
         <source>Sähköisen arkiston sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Location of the electronic archive</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.ui" line="20"/>
         <source>Kirjanpidon sähköinen arkisto on omalla tietokoneellasi oleva hakemisto, minne kirjanpito tallennetaan muodossa, jossa sitä voi lukea selaimella ilman Kitsas-ohjelmaa. 
 
 Valitse, mihin hakemistoon arkisto tallennetaan</source>
-        <translation type="unfinished"></translation>
+        <translation>The electronic archive of the accounting is a directory on your own computer where the accounting is saved in a format that can be read with a browser without the Kitsas program. 
+
+Choose which directory the archive will be saved to</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.ui" line="34"/>
         <source>Arkistohakemiston sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Location of the archive directory</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.ui" line="56"/>
         <source>Vaihda hakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Change directory</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.ui" line="69"/>
         <source>Hakemiston nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Directory name</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.cpp" line="91"/>
         <source>Virhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.cpp" line="91"/>
         <source>Arkistohakemiston luominen epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create the archive directory.</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistohakemistodialogi.cpp" line="98"/>
         <source>Valitse hakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Choose directory</translation>
     </message>
 </context>
 <context>
@@ -1323,12 +1342,12 @@ Valitse, mihin hakemistoon arkisto tallennetaan</source>
     <message>
         <location filename="../arkistoija/arkistoija.cpp" line="52"/>
         <source>Arkistoidaan kirjanpitoa</source>
-        <translation type="unfinished"></translation>
+        <translation>Archiving accounting</translation>
     </message>
     <message>
         <location filename="../arkistoija/arkistoija.cpp" line="52"/>
         <source>Peruuta</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
 </context>
 <context>
@@ -1336,29 +1355,31 @@ Valitse, mihin hakemistoon arkisto tallennetaan</source>
     <message>
         <location filename="../arkisto/arkistonvienti.ui" line="20"/>
         <source>Arkiston vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>Export archive</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistonvienti.ui" line="36"/>
         <source>Vie hakemistoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Export to directory</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistonvienti.ui" line="50"/>
         <source>Arkisto tallennetaan käyttövalmiina haluamaasi hakemistoon. Helppo siirtää esimerkiksi USB-muistilla.
 
 Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltavaa tehdä uusi hakemisto.</source>
-        <translation type="unfinished"></translation>
+        <translation>The archive is saved ready-to-use in your desired directory. Easy to transfer, for example, on a USB drive.
+
+Numerous files will be copied to the directory, so it&apos;s recommended to create a new directory for the archive.</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistonvienti.ui" line="68"/>
         <source>Vie zip-tiedostona</source>
-        <translation type="unfinished"></translation>
+        <translation>Export as zip file</translation>
     </message>
     <message>
         <location filename="../arkisto/arkistonvienti.ui" line="79"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Arkistosta muodostetaan yksi zip-muotoinen paketti, joka on helppo arkistoida tai välittää edelleen. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The archive is created as a single zip package, which is easy to archive or forward. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -1366,134 +1387,134 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="14"/>
         <source>Asiakkaan / toimittajan tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer / supplier information</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="28"/>
         <source>Perustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic information</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="34"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="62"/>
         <source>Maa</source>
-        <translation type="unfinished"></translation>
+        <translation>Country</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="75"/>
         <source>Y-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="88"/>
         <source>Alv-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT number</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="102"/>
         <location filename="../rekisteri/asiakastoimittajadlg.cpp" line="267"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="115"/>
         <source>Lähiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Street address</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="138"/>
         <source>Postiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Postal address</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="158"/>
         <source>Puhelinnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="168"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="178"/>
         <source>Laskutustapa</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing method</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="188"/>
         <source>Maksuaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment term</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="200"/>
         <source> vrk</source>
-        <translation type="unfinished"></translation>
+        <translation> days</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="241"/>
         <source>Alue/osavaltio</source>
-        <translation type="unfinished"></translation>
+        <translation>Region/state</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="251"/>
         <source>Verkkolaskun vastaanottajalle pitää määrittää myös postiosoite.</source>
-        <translation type="unfinished"></translation>
+        <translation>A postal address must also be specified for the e-invoice recipient.</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="263"/>
         <source>Ryhmät</source>
-        <translation type="unfinished"></translation>
+        <translation>Groups</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="277"/>
         <location filename="../rekisteri/asiakastoimittajadlg.cpp" line="270"/>
         <source>Verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="283"/>
         <source>Välittäjätunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Intermediary ID</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="300"/>
         <source>Verkkolaskuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice address</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="342"/>
         <source>Syötä ensin y-tunnus perustietoihin</source>
-        <translation type="unfinished"></translation>
+        <translation>First enter the business ID in the basic information</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="349"/>
         <source>Osoitteisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Address book</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="371"/>
         <source>Pankkitilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank accounts</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.ui" line="392"/>
         <source>Lisätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional information</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.cpp" line="261"/>
         <source>Tulostus</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../rekisteri/asiakastoimittajadlg.cpp" line="263"/>
         <source>Postitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Mailing</translation>
     </message>
 </context>
 <context>
@@ -1501,7 +1522,7 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../rekisteri/asiakastoimittajavalinta.cpp" line="68"/>
         <source>Y-tunnus tai nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID or name</translation>
     </message>
 </context>
 <context>
@@ -1509,22 +1530,22 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../laskutus/asiakkaatmodel.cpp" line="78"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../laskutus/asiakkaatmodel.cpp" line="80"/>
         <source>Yhteensä</source>
-        <translation type="unfinished"></translation>
+        <translation>Total</translation>
     </message>
     <message>
         <location filename="../laskutus/asiakkaatmodel.cpp" line="84"/>
         <source>Erääntynyt</source>
-        <translation type="unfinished"></translation>
+        <translation>Overdue</translation>
     </message>
     <message>
         <location filename="../laskutus/asiakkaatmodel.cpp" line="82"/>
         <source>Avoinna</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
 </context>
 <context>
@@ -1532,32 +1553,32 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/tilinavaus/avauseradlg.ui" line="14"/>
         <source>Tilinavaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening entry</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseradlg.ui" line="26"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseradlg.ui" line="33"/>
         <source>Merkitse tilillä olevat erät avaavasta taseesta</source>
-        <translation type="unfinished"></translation>
+        <translation>Mark items on the account from the opening balance</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseradlg.ui" line="43"/>
         <source>Merkitse edellisen tilikauden tulos eri kohdennuksille jaoteltuna</source>
-        <translation type="unfinished"></translation>
+        <translation>Mark the result of the previous accounting period divided into different allocations</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseradlg.ui" line="56"/>
         <source>Yhteensä 0 €</source>
-        <translation type="unfinished"></translation>
+        <translation>Total 0 €</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseradlg.cpp" line="104"/>
         <source>Yhteensä %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Total %1</translation>
     </message>
 </context>
 <context>
@@ -1565,27 +1586,27 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/tilinavaus/avauseramodel.cpp" line="30"/>
         <source>Asiakas/toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/supplier</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseramodel.cpp" line="32"/>
         <source>Erän nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Item name</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseramodel.cpp" line="34"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseramodel.cpp" line="36"/>
         <source>Poistoaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Depreciation period</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauseramodel.cpp" line="77"/>
         <source>%1 vuotta</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 years</translation>
     </message>
 </context>
 <context>
@@ -1593,12 +1614,12 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/tilinavaus/avauskohdennusmodel.cpp" line="29"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauskohdennusmodel.cpp" line="31"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
 </context>
 <context>
@@ -1606,17 +1627,17 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/tilinavaus/avauskuukausimodel.cpp" line="16"/>
         <source>Kuukausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Month</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauskuukausimodel.cpp" line="18"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/avauskuukausimodel.cpp" line="20"/>
         <source>Erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Specification</translation>
     </message>
 </context>
 <context>
@@ -1624,47 +1645,47 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/bannerdialog.ui" line="14"/>
         <source>Laskun banneri</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice banner</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.ui" line="32"/>
         <source>Valitse kuva...</source>
-        <translation type="unfinished"></translation>
+        <translation>Select image...</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.ui" line="43"/>
         <source>Bannerin nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Banner name</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.ui" line="53"/>
         <source>Tunniste</source>
-        <translation type="unfinished"></translation>
+        <translation>Identifier</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.ui" line="72"/>
         <source>Bannerin nimi ei tulostu laskulle.</source>
-        <translation type="unfinished"></translation>
+        <translation>The banner name will not be printed on the invoice.</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.cpp" line="56"/>
         <source>Valitse lisättävä bannerikuva</source>
-        <translation type="unfinished"></translation>
+        <translation>Select banner image to add</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.cpp" line="58"/>
         <source>Kuvatiedostot (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
+        <translation>Image files (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.cpp" line="66"/>
         <source>Bannerikuvan muoto ei kelpaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid banner image format</translation>
     </message>
     <message>
         <location filename="../maaritys/bannerdialog.cpp" line="66"/>
         <source>Bannerikuvan korkeus saa olla korkeintaan kolmasosa kuvan leveydestä.</source>
-        <translation type="unfinished"></translation>
+        <translation>The height of the banner image should not exceed one-third of its width.</translation>
     </message>
 </context>
 <context>
@@ -1672,27 +1693,27 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/bannermaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/bannermaaritys.ui" line="25"/>
         <source>Laskujen bannerit</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice banners</translation>
     </message>
     <message>
         <location filename="../maaritys/bannermaaritys.ui" line="54"/>
         <source>Uusi banneri...</source>
-        <translation type="unfinished"></translation>
+        <translation>New banner...</translation>
     </message>
     <message>
         <location filename="../maaritys/bannermaaritys.ui" line="65"/>
         <source>Muokkaa...</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit...</translation>
     </message>
     <message>
         <location filename="../maaritys/bannermaaritys.ui" line="76"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
@@ -1700,7 +1721,7 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../model/bannermodel.cpp" line="35"/>
         <source>Ei banneria</source>
-        <translation type="unfinished"></translation>
+        <translation>No banner</translation>
     </message>
 </context>
 <context>
@@ -1708,62 +1729,62 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="14"/>
         <source>Budjetti</source>
-        <translation type="unfinished"></translation>
+        <translation>Budget</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="22"/>
         <source>&amp;Tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="35"/>
         <source>&amp;Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;llocation</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="50"/>
         <source>Syötä menot miinusmerkkisinä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter expenses as negative numbers.</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="75"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="82"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="89"/>
         <source>Kopioi &amp;edellisestä</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy from &amp;previous</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="113"/>
         <source>   0,00  €</source>
-        <translation type="unfinished"></translation>
+        <translation>   0,00 €</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="133"/>
         <source>&amp;Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Save</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.ui" line="144"/>
         <source>&amp;Sulje</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Close</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.cpp" line="99"/>
         <source>Budjettia muokattu</source>
-        <translation type="unfinished"></translation>
+        <translation>Budget modified</translation>
     </message>
     <message>
         <location filename="../arkisto/budjettidlg.cpp" line="100"/>
         <source>Tallennetaanko muokattu budjetti?</source>
-        <translation type="unfinished"></translation>
+        <translation>Save modified budget?</translation>
     </message>
 </context>
 <context>
@@ -1771,32 +1792,32 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../raportti/budjettivertailu.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../raportti/budjettivertailu.ui" line="20"/>
         <source>Tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period</translation>
     </message>
     <message>
         <location filename="../raportti/budjettivertailu.ui" line="33"/>
         <source>Raportin muoto</source>
-        <translation type="unfinished"></translation>
+        <translation>Report format</translation>
     </message>
     <message>
         <location filename="../raportti/budjettivertailu.ui" line="46"/>
         <source>Kohdennuksella</source>
-        <translation type="unfinished"></translation>
+        <translation>With Allocation</translation>
     </message>
     <message>
         <location filename="../raportti/budjettivertailu.ui" line="64"/>
         <source>Tulosta tilikohtaiset erittelyt</source>
-        <translation type="unfinished"></translation>
+        <translation>Print account-specific details</translation>
     </message>
     <message>
         <location filename="../raportti/budjettivertailu.ui" line="88"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
 </context>
 <context>
@@ -1804,57 +1825,57 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="14"/>
         <source>CSV-tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>CSV import</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="20"/>
         <source>Tuo</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="26"/>
         <source>Kirjauksia</source>
-        <translation type="unfinished"></translation>
+        <translation>Entries</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="36"/>
         <source>Tilitapahtumia tilille</source>
-        <translation type="unfinished"></translation>
+        <translation>Account transactions</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="53"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="58"/>
         <source>Tyyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="63"/>
         <source>Tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="68"/>
         <source>Esimerkki</source>
-        <translation type="unfinished"></translation>
+        <translation>Example</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="76"/>
         <source>Tilinumeroiden muunto</source>
-        <translation type="unfinished"></translation>
+        <translation>Account number conversion</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="88"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuontidlg.ui" line="95"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
 </context>
 <context>
@@ -1862,73 +1883,73 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="14"/>
         <source>CSV-viennin valinnat</source>
-        <translation type="unfinished"></translation>
+        <translation>CSV export options</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="20"/>
         <source>Kenttien erotin</source>
-        <translation type="unfinished"></translation>
+        <translation>Field separator</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="26"/>
         <location filename="../raportti/csvvientivalinnat.ui" line="109"/>
         <source>Pilkku ,</source>
-        <translation type="unfinished"></translation>
+        <translation>Comma ,</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="33"/>
         <source>Puolipiste ;</source>
-        <translation type="unfinished"></translation>
+        <translation>Semicolon ;</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="40"/>
         <source>Sarkain</source>
-        <translation type="unfinished"></translation>
+        <translation>Tab</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="50"/>
         <source>Merkistö</source>
-        <translation type="unfinished"></translation>
+        <translation>Character set</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="56"/>
         <source>UTF-8</source>
-        <translation type="unfinished"></translation>
+        <translation>UTF-8</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="63"/>
         <source>Latin 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Latin 1</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="73"/>
         <source>Päivämäärän muoto</source>
-        <translation type="unfinished"></translation>
+        <translation>Date format</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="79"/>
         <source>pp.kk.vvvv</source>
-        <translation type="unfinished"></translation>
+        <translation>dd.mm.yyyy</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="86"/>
         <source>vvvv-kk-pp</source>
-        <translation type="unfinished"></translation>
+        <translation>yyyy-mm-dd</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="93"/>
         <source>kk/pp/vvvv</source>
-        <translation type="unfinished"></translation>
+        <translation>mm/dd/yyyy</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="103"/>
         <source>Desimaalierotin</source>
-        <translation type="unfinished"></translation>
+        <translation>Decimal separator</translation>
     </message>
     <message>
         <location filename="../raportti/csvvientivalinnat.ui" line="116"/>
         <source>Piste .</source>
-        <translation type="unfinished"></translation>
+        <translation>Period .</translation>
     </message>
 </context>
 <context>
@@ -1937,47 +1958,47 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
         <location filename="../aloitussivu/debugtiedotdlg.ui" line="14"/>
         <location filename="../aloitussivu/debugtiedotdlg.ui" line="80"/>
         <source>Virheenjäljitystiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Debug information</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.ui" line="20"/>
         <source>Tällä toiminnolla voit tuen pyytäessä lähettää tukeen teknisiä tietoja, jotka voivat auttaa ongelmasi ratkaisemisessa.</source>
-        <translation type="unfinished"></translation>
+        <translation>With this function, you can send technical information to support when requested, which can help in solving your problem.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.ui" line="38"/>
         <source>Kuvaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.ui" line="44"/>
         <source>Kirjoita tähän lyhyt kuvaus ongelmasta</source>
-        <translation type="unfinished"></translation>
+        <translation>Write a brief description of the problem here</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.ui" line="56"/>
         <source>Järjestelmätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>System information</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.cpp" line="44"/>
         <source>Tiedot lähetetty</source>
-        <translation type="unfinished"></translation>
+        <translation>Information sent</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.cpp" line="45"/>
         <source>Tekniset tiedot on nyt lähetty tuen luettavaksi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Technical information has now been sent for support to read.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.cpp" line="52"/>
         <source>Tietojen lähettäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to send information</translation>
     </message>
     <message>
         <location filename="../aloitussivu/debugtiedotdlg.cpp" line="53"/>
         <source>Tietojen lähettäminen tukee epäonnistui. Yritä hetken kuluttua uudestaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to send information to support. Please try again in a moment.</translation>
     </message>
 </context>
 <context>
@@ -1985,153 +2006,153 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../tools/devtool.ui" line="14"/>
         <source>Kehittäjän työkalut</source>
-        <translation type="unfinished"></translation>
+        <translation>Developer tools</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="32"/>
         <source>Loki</source>
-        <translation type="unfinished"></translation>
+        <translation>Log</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="69"/>
         <source>Leikepöydälle</source>
-        <translation type="unfinished"></translation>
+        <translation>To clipboard</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="87"/>
         <source>Asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="102"/>
         <source>Avain</source>
-        <translation type="unfinished"></translation>
+        <translation>Key</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="109"/>
         <source>Arvo</source>
-        <translation type="unfinished"></translation>
+        <translation>Value</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="131"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="142"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="153"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="160"/>
         <source>F10</source>
-        <translation type="unfinished"></translation>
+        <translation>F10</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="182"/>
         <source>Kysely</source>
-        <translation type="unfinished"></translation>
+        <translation>Query</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="196"/>
         <source>GET</source>
-        <translation type="unfinished"></translation>
+        <translation>GET</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="206"/>
         <source>POST</source>
-        <translation type="unfinished"></translation>
+        <translation>POST</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="213"/>
         <source>PUT</source>
-        <translation type="unfinished"></translation>
+        <translation>PUT</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="220"/>
         <source>PATCH</source>
-        <translation type="unfinished"></translation>
+        <translation>PATCH</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="227"/>
         <source>DELETE</source>
-        <translation type="unfinished"></translation>
+        <translation>DELETE</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="243"/>
         <source>Login</source>
-        <translation type="unfinished"></translation>
+        <translation>Login</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="250"/>
         <source>Cloud</source>
-        <translation type="unfinished"></translation>
+        <translation>Cloud</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="265"/>
         <source>Kirjoita polku ja paina Enter</source>
-        <translation type="unfinished"></translation>
+        <translation>Write the path and press Enter</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="286"/>
         <source>Tilikartan vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>Export Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="304"/>
         <source>Tällä toiminnolla voit viedä tililuettelon ja raportit käytettäväksi uusissa kirjanpidoissa. Kirjaukset eivät siirry tilikartan mukana.</source>
-        <translation type="unfinished"></translation>
+        <translation>With this function, you can export the chart of accounts and reports for use in new bookkeeping. Entries are not transferred with the chart of accounts.</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="318"/>
         <source>Tilikartan nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name of the Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="331"/>
         <source>Tilikartan tekijä</source>
-        <translation type="unfinished"></translation>
+        <translation>Author of the Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="374"/>
         <source>Vie tilikartta</source>
-        <translation type="unfinished"></translation>
+        <translation>Export Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../tools/devtool.ui" line="392"/>
         <source>Ristinolla</source>
-        <translation type="unfinished"></translation>
+        <translation>Tic-tac-toe</translation>
     </message>
     <message>
         <location filename="../tools/devtool.cpp" line="263"/>
         <source>Kitsaan tilikartta (*.kitsaskartta)</source>
         <comment>kitsaskartta on tiedostopääte - älä käännä!</comment>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas chart of accounts (*.kitsaskartta)</translation>
     </message>
     <message>
         <location filename="../tools/devtool.cpp" line="335"/>
         <source>Tilikartan vieminen onnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of Accounts exported successfully</translation>
     </message>
     <message>
         <location filename="../tools/devtool.cpp" line="336"/>
         <source>Tilikartta viety tiedostoon %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of Accounts exported to file %1</translation>
     </message>
     <message>
         <location filename="../tools/devtool.cpp" line="338"/>
         <source>Tilikartan vieminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to export Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../tools/devtool.cpp" line="339"/>
         <source>Tiedostoon %1 ei voitu kirjoittaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Could not write to file %1</translation>
     </message>
 </context>
 <context>
@@ -2139,107 +2160,107 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="32"/>
         <source>Tarkastetaan, onko SSL käytettävissä...</source>
-        <translation type="unfinished"></translation>
+        <translation>Checking if SSL is available...</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="41"/>
         <source>Sähköpostiasetusten tallennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Save email settings</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="47"/>
         <source>Tietokoneen asetuksiin</source>
-        <translation type="unfinished"></translation>
+        <translation>To computer settings</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="61"/>
         <source>Kirjanpitokohtaisesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Per bookkeeping</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="72"/>
         <source>Lähetä Kitsaan palvelimen kautta (vain pilvikirjanpidossa)</source>
-        <translation type="unfinished"></translation>
+        <translation>Send through Kitsas server (only in cloud bookkeeping)</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="86"/>
         <source>Smtp-palvelin</source>
-        <translation type="unfinished"></translation>
+        <translation>SMTP server</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="92"/>
         <source>Palvelin</source>
-        <translation type="unfinished"></translation>
+        <translation>Server</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="105"/>
         <source>Portti</source>
-        <translation type="unfinished"></translation>
+        <translation>Port</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="128"/>
         <source>Käyttäjänimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Username</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="141"/>
         <source>Salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="159"/>
         <source>Suojaamaton yhteys (TCP)</source>
-        <translation type="unfinished"></translation>
+        <translation>Unsecured connection (TCP)</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="168"/>
         <source>Salattu yhteys (SSL)</source>
-        <translation type="unfinished"></translation>
+        <translation>Encrypted connection (SSL)</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="177"/>
         <source>Suojattu yhteys (STARTTLS)</source>
-        <translation type="unfinished"></translation>
+        <translation>Secured connection (STARTTLS)</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="207"/>
         <source>Testisähköpostia lähetetään...</source>
-        <translation type="unfinished"></translation>
+        <translation>Sending test email...</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="214"/>
         <source>Kokeile</source>
-        <translation type="unfinished"></translation>
+        <translation>Test</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="227"/>
         <source>Viestien lähettäjä</source>
-        <translation type="unfinished"></translation>
+        <translation>Message sender</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="233"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="246"/>
         <source>Sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="259"/>
         <source>Vain minun lähettämissäni viesteissä</source>
-        <translation type="unfinished"></translation>
+        <translation>Only in messages I send</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.ui" line="271"/>
         <source>Laskukopio osoitteeseen</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice copy to address</translation>
     </message>
 </context>
 <context>
@@ -2247,45 +2268,45 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="73"/>
         <source>&lt;b&gt;SSL-suojattu verkkoliikenne ei käytössä&lt;/b&gt;&lt;p&gt;Laskujen lähettäminen suojatulla sähköpostilla edellyttää OpenSSL-kirjaston versiota %1&lt;p&gt;Voidaksesi lähettää suojattua sähköpostia lataa Internetistä ja asenna OpenSSL-kirjasto %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;SSL-secured network traffic not in use&lt;/b&gt;&lt;p&gt;Sending invoices via secure email requires OpenSSL library version %1&lt;p&gt;To send secure email, download and install OpenSSL library %1 from the Internet.</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="165"/>
         <location filename="../maaritys/emailmaaritys.cpp" line="169"/>
         <source>Puutteelliset asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Incomplete settings</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="165"/>
         <source>Lähettäjän sähköpostiosoitetta ei ole määritelty</source>
-        <translation type="unfinished"></translation>
+        <translation>Sender&apos;s email address is not defined</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="169"/>
         <source>Sähköpostipalvelinta ei ole määritelty</source>
-        <translation type="unfinished"></translation>
+        <translation>Email server is not defined</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="200"/>
         <source>Vastausosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Reply address</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="200"/>
         <source>Sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="211"/>
         <location filename="../maaritys/emailmaaritys.cpp" line="277"/>
         <source>Kitsaan sähköpostikokeilu</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas email test</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="213"/>
         <location filename="../maaritys/emailmaaritys.cpp" line="278"/>
         <source>Sähköpostin lähettäminen Kitsas-ohjelmasta onnistui %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Sending email from Kitsas program succeeded %1</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="225"/>
@@ -2293,35 +2314,35 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
         <location filename="../maaritys/emailmaaritys.cpp" line="242"/>
         <location filename="../maaritys/emailmaaritys.cpp" line="300"/>
         <source>Sähköpostin lähettäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Sending email failed</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="225"/>
         <source>Sähköpostipalvelimeen %1 yhdistäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Connection to email server %1 failed</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="234"/>
         <source>Sähköpostipalvelimeen kirjautuminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Login to email server failed</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="242"/>
         <location filename="../maaritys/emailmaaritys.cpp" line="300"/>
         <source>Virhe sähköpostia lähetettäessä</source>
-        <translation type="unfinished"></translation>
+        <translation>Error while sending email</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="244"/>
         <location filename="../maaritys/emailmaaritys.cpp" line="293"/>
         <source>Sähköposti lähetetty</source>
-        <translation type="unfinished"></translation>
+        <translation>Email sent</translation>
     </message>
     <message>
         <location filename="../maaritys/emailmaaritys.cpp" line="244"/>
         <location filename="../maaritys/emailmaaritys.cpp" line="293"/>
         <source>Sähköpostin lähettäminen onnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Email sending succeeded</translation>
     </message>
 </context>
 <context>
@@ -2329,12 +2350,12 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../laskutus/ennakkohyvitysdialogi.ui" line="14"/>
         <source>Hyvitä ennakkolaskua</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit advance invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/ennakkohyvitysdialogi.ui" line="35"/>
         <source>Hyvitettävä määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount to be credited</translation>
     </message>
 </context>
 <context>
@@ -2342,17 +2363,17 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../laskutus/laskudlg/ennakkohyvitysmodel.cpp" line="31"/>
         <source>Päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/ennakkohyvitysmodel.cpp" line="32"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/ennakkohyvitysmodel.cpp" line="33"/>
         <source>Euroa</source>
-        <translation type="unfinished"></translation>
+        <translation>Euros</translation>
     </message>
 </context>
 <context>
@@ -2360,22 +2381,22 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../tools/eracombo.cpp" line="100"/>
         <source>Ei tase-erää (Erittelemätön)</source>
-        <translation type="unfinished"></translation>
+        <translation>No balance item (Unspecified)</translation>
     </message>
     <message>
         <location filename="../tools/eracombo.cpp" line="101"/>
         <source>Uusi tase-erä</source>
-        <translation type="unfinished"></translation>
+        <translation>New balance item</translation>
     </message>
     <message>
         <location filename="../tools/eracombo.cpp" line="102"/>
         <source>Valitse tase-erä</source>
-        <translation type="unfinished"></translation>
+        <translation>Select balance sheet item</translation>
     </message>
     <message>
         <location filename="../tools/eracombo.cpp" line="111"/>
         <source>Huoneisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Apartment</translation>
     </message>
 </context>
 <context>
@@ -2383,87 +2404,87 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="40"/>
         <source>Tase-erien selvittely %1-%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance item reconciliation %1-%2</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="113"/>
         <source>Tase-erien selvittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet item reconciliation</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="117"/>
         <source>Nollatut</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeroed</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="123"/>
         <source>Etsi...</source>
-        <translation type="unfinished"></translation>
+        <translation>Search...</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="128"/>
         <source>Päivitä</source>
-        <translation type="unfinished"></translation>
+        <translation>Update</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="132"/>
         <source>Tase-erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet specification</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="142"/>
         <source>Näytä tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Show Voucher</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="145"/>
         <source>Uusi erä</source>
-        <translation type="unfinished"></translation>
+        <translation>New entry</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="148"/>
         <source>Siirrä erään</source>
-        <translation type="unfinished"></translation>
+        <translation>Move to Entry</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="151"/>
         <source>Erittelemättömiin</source>
-        <translation type="unfinished"></translation>
+        <translation>To Unspecified</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="154"/>
         <source>Nollaustosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeroing Voucher</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="157"/>
         <source>Uudelleennimeä</source>
-        <translation type="unfinished"></translation>
+        <translation>Rename</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="166"/>
         <source>Toiminnot</source>
-        <translation type="unfinished"></translation>
+        <translation>Functions</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="188"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="373"/>
         <source>Vaihda selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Change Description</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="374"/>
         <source>Viennin selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Transaction Description</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitys.cpp" line="374"/>
         <source>Korvaa viennin selitteen myös kirjanpitotositteella.</source>
-        <translation type="unfinished"></translation>
+        <translation>Replace the transaction description also in the accounting voucher.</translation>
     </message>
 </context>
 <context>
@@ -2471,32 +2492,32 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../raportti/eranselvittaja/eranselvityseramodel.cpp" line="15"/>
         <source>Pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvityseramodel.cpp" line="16"/>
         <source>Asiakas/Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/Supplier</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvityseramodel.cpp" line="17"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvityseramodel.cpp" line="18"/>
         <source>Kausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Period</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvityseramodel.cpp" line="19"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvityseramodel.cpp" line="58"/>
         <source>Erittelemättömät</source>
-        <translation type="unfinished"></translation>
+        <translation>Unspecified</translation>
     </message>
 </context>
 <context>
@@ -2504,22 +2525,22 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitystilimodel.cpp" line="17"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitystilimodel.cpp" line="19"/>
         <source>Kausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Period</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitystilimodel.cpp" line="21"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitystilimodel.cpp" line="55"/>
         <source>Tiliöimättä</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated</translation>
     </message>
 </context>
 <context>
@@ -2527,32 +2548,32 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitysviennit.cpp" line="18"/>
         <source>Päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitysviennit.cpp" line="19"/>
         <source>Tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitysviennit.cpp" line="20"/>
         <source>Asiakas/Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/Supplier</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitysviennit.cpp" line="21"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitysviennit.cpp" line="22"/>
         <source>Debet</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit</translation>
     </message>
     <message>
         <location filename="../raportti/eranselvittaja/eranselvitysviennit.cpp" line="23"/>
         <source>Kredit</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit</translation>
     </message>
 </context>
 <context>
@@ -2560,22 +2581,22 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../tools/eranvalintadialog.ui" line="14"/>
         <source>Valitse tase-erä</source>
-        <translation type="unfinished"></translation>
+        <translation>Select balance sheet item</translation>
     </message>
     <message>
         <location filename="../tools/eranvalintadialog.ui" line="25"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../tools/eranvalintadialog.ui" line="35"/>
         <source>Avoimet</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
     <message>
         <location filename="../tools/eranvalintadialog.ui" line="47"/>
         <source>Suodata tekstillä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by text</translation>
     </message>
 </context>
 <context>
@@ -2583,22 +2604,22 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../tools/eranvalintamodel.cpp" line="29"/>
         <source>Pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../tools/eranvalintamodel.cpp" line="30"/>
         <source>Asiakas/Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/Supplier</translation>
     </message>
     <message>
         <location filename="../tools/eranvalintamodel.cpp" line="31"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../tools/eranvalintamodel.cpp" line="32"/>
         <source>Avoin saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Open balance</translation>
     </message>
 </context>
 <context>
@@ -2606,63 +2627,64 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="33"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="106"/>
         <source>Ilmoitettu rajapinnan kautta</source>
-        <translation type="unfinished"></translation>
+        <translation>Reported via interface</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="123"/>
         <source>Virhe ilmoittamisessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Error in reporting</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="124"/>
         <source>Alv-ilmoituksen toimittaminen verottajalle epäonnistui.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to submit VAT return to tax authorities.
+</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="133"/>
         <source>Yhteisömyynnin yhteenvetoilmoitus %1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Intra-community sales summary report %1/%2</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="179"/>
         <source>Yhteisömyynti-ilmoitus annetaan kirjanpidossa olevien tietojen mukaisesti, asiakkaan tietoihin syötettyjen alv-tunnusten mukaisesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Intra-community sales report is submitted based on the information in the accounting records, according to the VAT numbers entered in the customer information</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="182"/>
         <source>YHTEISÖMYYNNIN YHTEENVETOILMOITUS</source>
-        <translation type="unfinished"></translation>
+        <translation>INTRA-COMMUNITY SALES SUMMARY REPORT</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="190"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="191"/>
         <source>Alv-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT number</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="192"/>
         <source>Tavaramyynti</source>
-        <translation type="unfinished"></translation>
+        <translation>Goods sale</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="193"/>
         <source>Palvelumyynti</source>
-        <translation type="unfinished"></translation>
+        <translation>Service sales</translation>
     </message>
     <message>
         <location filename="../alv/eumyyntiyhteenvetodialogi.cpp" line="221"/>
         <source>Yhteensä</source>
-        <translation type="unfinished"></translation>
+        <translation>Total</translation>
     </message>
 </context>
 <context>
@@ -2670,12 +2692,12 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/extra/extralogmodel.cpp" line="17"/>
         <source>Aika</source>
-        <translation type="unfinished"></translation>
+        <translation>Time</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/extralogmodel.cpp" line="18"/>
         <source>Tapahtuma</source>
-        <translation type="unfinished"></translation>
+        <translation>Event</translation>
     </message>
 </context>
 <context>
@@ -2683,12 +2705,12 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../tools/finvoicehaku.cpp" line="90"/>
         <source>Noudetaan uusia verkkolaskuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Fetching new e-invoices</translation>
     </message>
     <message>
         <location filename="../tools/finvoicehaku.cpp" line="226"/>
         <source>%1 verkkolaskua haettu</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 e-invoices retrieved</translation>
     </message>
 </context>
 <context>
@@ -2696,57 +2718,57 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="43"/>
         <source>Verkkolaskutusta ei ole määritelty käyttöön kirjanpidon asetuksista</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoicing has not been enabled in accounting settings</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="45"/>
         <source>Verkkolaskujen toimittaminen edellyttää kirjautumista Kitsaan pilveen</source>
-        <translation type="unfinished"></translation>
+        <translation>Sending e-invoices requires logging into Kitsas cloud</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="47"/>
         <source>Laskutuksen asetuksissa ei ole määritelty yhtään tilinumeroa.</source>
-        <translation type="unfinished"></translation>
+        <translation>No account number has been defined in the invoicing settings.</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="91"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="97"/>
         <source>Verkkolaskun muodostaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to generate e-invoice</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="108"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="114"/>
         <source>Laskutiedoston tallentaminen sijaintiin %1 epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save invoice file to location %1</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="122"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="128"/>
         <source>Verkkolaskun saajalle ei ole määritelty verkkolaskutusosoitetta</source>
-        <translation type="unfinished"></translation>
+        <translation>The e-invoice recipient has not been assigned an e-invoicing address</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="184"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="190"/>
         <source>Verkkolaskun kuvan liittäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to attach the e-invoice image</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="217"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="223"/>
         <source>Liitteen liittäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to attach the attachment</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="251"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="257"/>
         <source>Lähetetyksi merkitseminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to mark as sent</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="255"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="261"/>
         <source>Verkkolaskun lähettäminen Maventan palveluun epäonnistui. Tarkasta verkkolaskutuksen asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to send the e-invoice to Maventa service. Check the e-invoicing settings</translation>
     </message>
     <message>
-        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="262"/>
+        <location filename="../laskutus/toimittaja/finvoicetoimittaja.cpp" line="268"/>
         <source>Käyttäjää ei ole yhdistetty Maventan tunnukseen. Määritä käyttäjä verkkolaskutuksen asetuksista.</source>
-        <translation type="unfinished"></translation>
+        <translation>The user is not linked to a Maventa account. Define the user in the e-invoicing settings.</translation>
     </message>
 </context>
 <context>
@@ -2754,42 +2776,42 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="43"/>
         <source>Ota verkkolaskutus käyttöön</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable e-invoicing</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="44"/>
         <source>Verkkolaskutilin valinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Select e-invoice account</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="88"/>
         <source>Tarkasta tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Check information</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="89"/>
         <source>Jos tiedot ovat puutteelliset, korjaa oikeat tiedot ohjelman asetuksiin ennen jatkamista.</source>
-        <translation type="unfinished"></translation>
+        <translation>If the information is incomplete, correct the right information in the program settings before continuing.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="113"/>
         <source>Sähköinen allekirjoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Electronic signature</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="114"/>
         <source>Anna sähköpostiosoite sähköistä allekirjoitusta varten</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter email address for electronic signature</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="138"/>
         <source>Viimeistele käyttöönotto</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalize setup</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelho.cpp" line="139"/>
         <source>Verkkolaskutus valmis käyttöön otettavaksi</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoicing ready to be activated</translation>
     </message>
 </context>
 <context>
@@ -2797,48 +2819,49 @@ Hakemistoon kopioidaan lukuisia tiedostoja, joten arkistoa varten on suositeltav
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="25"/>
         <source>Uusi verkkolaskutili</source>
-        <translation type="unfinished"></translation>
+        <translation>New e-invoice account</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="32"/>
         <source>Ota käyttöön Kitsaan integroitu verkkolaskutus.
 Kitsas Oy laskuttaa lähetetyistä ja vastaanotetuista verkkolaskuista &lt;a href=&quot;https://kitsas.fi/hinnat&quot;&gt;hinnastonsa&lt;/a&gt; mukaisesti. Verkkolaskupalvelun tuottaa Maventa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable Kitsas integrated e-invoicing.
+Kitsas Oy charges for sent and received e-invoices according to its &lt;a href=&quot;https://kitsas.fi/hinnat&quot;&gt;price list&lt;/a&gt;. The e-invoicing service is provided by Maventa.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="49"/>
         <source>Yritykselläsi on jo Maventan verkkolaskutunnukset, joten et voi luoda uutta verkkolaskutiliä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Your company already has Maventa&apos;s e-invoicing credentials, so you cannot create a new e-invoicing account.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="59"/>
         <source>Kitsaalla voi luoda verkkolaskutilin vain pilveen tallennetuille kirjanpidoille.</source>
-        <translation type="unfinished"></translation>
+        <translation>With Kitsas, you can only create an e-invoice account for cloud-stored accounting records.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="71"/>
         <source>Olemassa oleva Maventan verkkolaskutili</source>
-        <translation type="unfinished"></translation>
+        <translation>Existing Maventa e-invoice account</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="78"/>
         <source>Integroitu verkkolaskutus olemassa olevia Maventan tunnuksen käyttäen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Integrated e-invoicing using existing Maventa credentials.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="93"/>
         <source>Verkkolaskujen muodostaminen tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating e-invoices to a file</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoalku.ui" line="100"/>
         <source>Huolehdit itse Kitsaan tiedostoon muodostaman aineiston toimittamisesta verkkolaskuoperaattorille.</source>
-        <translation type="unfinished"></translation>
+        <translation>You are responsible for delivering the material generated by Kitsas to the e-invoice operator.</translation>
     </message>
 </context>
 <context>
@@ -2846,18 +2869,19 @@ Kitsas Oy laskuttaa lähetetyistä ja vastaanotetuista verkkolaskuista &lt;a hre
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoemail.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoemail.ui" line="22"/>
         <source>Allekirjoittajan sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Signer&apos;s email address</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhoemail.ui" line="34"/>
         <source>Ennen verkkolaskujen lähettämistä ja vastaanottamista pitää verkkolaskutili vahvistaa sähköisellä allekirjoituksella. Allekirjoittajalla on oltava nimenkirjoitusoikeus organisaatiossa.
 Ohjeet lähetetään allekirjoittajalle sähköpostissa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Before sending and receiving e-invoices, the e-invoice account must be confirmed with an electronic signature. The signer must have the right to sign on behalf of the organization.
+Instructions will be sent to the signer via email.</translation>
     </message>
 </context>
 <context>
@@ -2865,37 +2889,37 @@ Ohjeet lähetetään allekirjoittajalle sähköpostissa.</source>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhotiedot.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhotiedot.ui" line="22"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhotiedot.ui" line="36"/>
         <source>Y-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhotiedot.ui" line="50"/>
         <source>Osoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Address</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhotiedot.ui" line="67"/>
         <source>Kotipaikka</source>
-        <translation type="unfinished"></translation>
+        <translation>Domicile</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhotiedot.ui" line="81"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhotiedot.ui" line="95"/>
         <source>Kotisivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Homepage</translation>
     </message>
 </context>
 <context>
@@ -2903,7 +2927,7 @@ Ohjeet lähetetään allekirjoittajalle sähköpostissa.</source>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhovalmis.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhovalmis.ui" line="20"/>
@@ -2912,22 +2936,26 @@ Ohjeet lähetetään allekirjoittajalle sähköpostissa.</source>
 Verkkolaskutus on käytössä noin tunnin kuluttua allekirjoittamisesta.
 
 Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, että voit ottaa vastaan verkkolaskuja kaikkien suomalaisten verkkolaskuoperaattoreiden asiakkailta.</source>
-        <translation type="unfinished"></translation>
+        <translation>An email will be sent to the signer with instructions for confirming the activation of e-invoicing.
+
+E-invoicing will be available about an hour after signing.
+
+Your company will also be connected to the banking network and e-invoice address directory so that you can receive e-invoices from customers of all Finnish e-invoice operators.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhovalmis.ui" line="34"/>
         <source>Sähköposti-ilmoitus saapuneista laskuista</source>
-        <translation type="unfinished"></translation>
+        <translation>Email notification for received invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhovalmis.ui" line="45"/>
         <source>Sähköposti-ilmoitus virheistä laskua lähetettäessä</source>
-        <translation type="unfinished"></translation>
+        <translation>Email notification for errors when sending an invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/finvoicevelhovalmis.ui" line="56"/>
         <source>Ota käyttöön postitettavien laskujen tulostuspalvelu</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable printing service for mailed invoices</translation>
     </message>
 </context>
 <context>
@@ -2935,118 +2963,118 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="25"/>
         <source>Kirjaudu Kitsaan pilveen muokataksesi verkkolaskutuksen asetuksia.</source>
-        <translation type="unfinished"></translation>
+        <translation>Log in to Kitsas cloud to modify e-invoicing settings.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="36"/>
         <source>Yhteystietosi ovat puutteelliset. Et voi muodostaa verkkolaskuja, ellei osoitetta, sähköpostiosoitetta, y-tunnusta ja kotipaikkaa ole määritelty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Your contact information is incomplete. You cannot create e-invoices unless your address, email address, business ID, and domicile are defined.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="49"/>
         <source>Odota, tietoja haetaan ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Please wait, retrieving information...</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="56"/>
         <source>Ota käyttöön</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="62"/>
         <source>Kitsaan integroidulla verkkolaskutuksella lähetät ja vastaanotat verkkolaskut helposti suoraan kirjanpitoosi.</source>
-        <translation type="unfinished"></translation>
+        <translation>With Kitsas integrated e-invoicing, you can easily send and receive e-invoices directly in your accounting.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="85"/>
         <source>Ota verkkolaskutus käyttöön...</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable e-invoicing...</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="99"/>
         <source>Finvoice-verkkolaskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Finvoice e-invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="105"/>
         <source>Ei käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Not in use</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="112"/>
         <source>Verkkolaskujen paikallinen muodostaminen tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Local creation of e-invoices to file</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="119"/>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="224"/>
         <source>Maventa-verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Maventa e-invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="129"/>
         <source>Oma verkkolaskuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Your e-invoice address</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="135"/>
         <source>Verkkolaskuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice address</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="145"/>
         <source>Välittäjän tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Intermediary ID</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="162"/>
         <source>Paikalliset asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Local settings</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="168"/>
         <source>Ohjelma muodostaa verkkolaskuja, mutta käyttäjän on itse ladattava ne verkkolaskuoperaattorille</source>
-        <translation type="unfinished"></translation>
+        <translation>The program creates e-invoices, but the user must upload them to the e-invoice operator themselves</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="180"/>
         <source>Tallennushakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Save directory</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="199"/>
         <source>Valitse hakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Choose directory</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="214"/>
         <source>Lisää SOAP-kehys</source>
-        <translation type="unfinished"></translation>
+        <translation>Add SOAP frame</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="250"/>
         <source>Noudetaan verkkolaskun käyttäjätietoja...</source>
-        <translation type="unfinished"></translation>
+        <translation>Retrieving e-invoice user information...</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="262"/>
         <source>Asetukset...</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings...</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="273"/>
         <source>Nouda nyt</source>
-        <translation type="unfinished"></translation>
+        <translation>Retrieve now</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolasku.ui" line="289"/>
         <source>Lähetä ensisijaisesti verkkolaskuna</source>
-        <translation type="unfinished"></translation>
+        <translation>Send primarily as e-invoice</translation>
     </message>
 </context>
 <context>
@@ -3054,37 +3082,37 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../toimisto/hubwebpage.cpp" line="17"/>
         <source>Seuraava sivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Next page</translation>
     </message>
     <message>
         <location filename="../toimisto/hubwebpage.cpp" line="18"/>
         <source>Edellinen sivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous page</translation>
     </message>
     <message>
         <location filename="../toimisto/hubwebpage.cpp" line="24"/>
         <source>Liitä</source>
-        <translation type="unfinished"></translation>
+        <translation>Paste</translation>
     </message>
     <message>
         <location filename="../toimisto/hubwebpage.cpp" line="26"/>
         <source>Kopioi</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy</translation>
     </message>
     <message>
         <location filename="../toimisto/hubwebpage.cpp" line="27"/>
         <source>Leikkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Cut</translation>
     </message>
     <message>
         <location filename="../toimisto/hubwebpage.cpp" line="31"/>
         <source>kumoa</source>
-        <translation type="unfinished"></translation>
+        <translation>undo</translation>
     </message>
     <message>
         <location filename="../toimisto/hubwebpage.cpp" line="32"/>
         <source>Tee uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Redo</translation>
     </message>
 </context>
 <context>
@@ -3092,37 +3120,37 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../laskutus/huoneisto/huoneistodialog.ui" line="14"/>
         <source>Huoneiston tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Apartment details</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistodialog.ui" line="26"/>
         <source>Huoneistotunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Apartment ID</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistodialog.ui" line="36"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistodialog.ui" line="60"/>
         <source>Kuukausilaskutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Monthly billing</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistodialog.ui" line="76"/>
         <source>Suodata tuotteita</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter products</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistodialog.ui" line="108"/>
         <source>Poista rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete row</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistodialog.ui" line="130"/>
         <source>Muistiinpanot</source>
-        <translation type="unfinished"></translation>
+        <translation>Notes</translation>
     </message>
 </context>
 <context>
@@ -3130,17 +3158,17 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../laskutus/huoneisto/huoneistolaskutusmodel.cpp" line="33"/>
         <source>Nimike</source>
-        <translation type="unfinished"></translation>
+        <translation>Item</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistolaskutusmodel.cpp" line="34"/>
         <source>Määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Quantity</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistolaskutusmodel.cpp" line="35"/>
         <source>Yksikkö</source>
-        <translation type="unfinished"></translation>
+        <translation>Unit</translation>
     </message>
 </context>
 <context>
@@ -3148,27 +3176,27 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../laskutus/huoneisto/huoneistomodel.cpp" line="34"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistomodel.cpp" line="35"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistomodel.cpp" line="36"/>
         <source>Laskutettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoiced</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistomodel.cpp" line="37"/>
         <source>Maksettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Paid</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/huoneistomodel.cpp" line="38"/>
         <source>Avoinna</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
 </context>
 <context>
@@ -3176,12 +3204,12 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../laskutus/laskudlg/hyvityslaskudialogi.cpp" line="33"/>
         <source>Hyvityslasku laskulle %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit note for invoice %1</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/hyvityslaskudialogi.cpp" line="35"/>
         <source>Hyvityslaskun pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit note date</translation>
     </message>
 </context>
 <context>
@@ -3189,7 +3217,7 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../rekisteri/ibandelegaatti.cpp" line="38"/>
         <source>Napsauta lisätäksesi tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Click to add account</translation>
     </message>
 </context>
 <context>
@@ -3197,35 +3225,36 @@ Yrityksesi liitetään myös pankkiverkkoon ja verkkolaskuosoitteistoon niin, et
     <message>
         <location filename="../alv/ilmoitintuottaja.cpp" line="93"/>
         <source>Tallenna Ilmoitin-aineisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Save Ilmoitin data</translation>
     </message>
     <message>
         <location filename="../alv/ilmoitintuottaja.cpp" line="94"/>
         <source>Tekstitiedostot (*.txt);;Kaikki tiedostot (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Text files (*.txt);;All files (*.*)</translation>
     </message>
     <message>
         <location filename="../alv/ilmoitintuottaja.cpp" line="102"/>
         <location filename="../alv/ilmoitintuottaja.cpp" line="109"/>
         <location filename="../alv/ilmoitintuottaja.cpp" line="122"/>
         <source>Ilmoitinaineiston muodostaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Generating Ilmoitin data</translation>
     </message>
     <message>
         <location filename="../alv/ilmoitintuottaja.cpp" line="103"/>
         <source>Ilmoitinaineiston tallentaminen tiedostoon epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save Ilmoitin data to file</translation>
     </message>
     <message>
         <location filename="../alv/ilmoitintuottaja.cpp" line="110"/>
         <source>Ilmoitinainesto tallennettu tiedostoon %1.
 Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ilmoitin data saved to file %1.
+You can send it to the tax authorities using the ilmoitin.fi service.</translation>
     </message>
     <message>
         <location filename="../alv/ilmoitintuottaja.cpp" line="123"/>
         <source>Ilmoitinaineiston muodostaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to generate Ilmoitin data</translation>
     </message>
 </context>
 <context>
@@ -3233,48 +3262,48 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../maaritys/inboxmaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Kirjattavien kansio&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kirjattavien kansio on tietokoneella oleva hakemisto, jonne on sijoitettu kirjattavaksi tulevia pdf- ja jpg-tositteita. Kitsas näyttää tämän hakemiston listauksen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Folder for recording&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The folder for recording is a directory on your computer where pdf and jpg vouchers to be recorded are placed. Kitsas displays a listing of this directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.ui" line="42"/>
         <location filename="../maaritys/inboxmaaritys.ui" line="98"/>
         <source>Valitse kansio</source>
-        <translation type="unfinished"></translation>
+        <translation>Select folder</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.ui" line="53"/>
         <source>Poista käytöstä</source>
-        <translation type="unfinished"></translation>
+        <translation>Disable</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.ui" line="66"/>
         <source>Kun tosite on kirjattu kirjattavien kansiosta...</source>
-        <translation type="unfinished"></translation>
+        <translation>When a voucher has been recorded from the recording folder...</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.ui" line="72"/>
         <source>Poista tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete voucher</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.ui" line="79"/>
         <source>Siirrä se kansioon</source>
-        <translation type="unfinished"></translation>
+        <translation>Move it to folder</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.cpp" line="87"/>
         <source>Valitse kirjattavien tositteiden kansio</source>
-        <translation type="unfinished"></translation>
+        <translation>Select folder for vouchers to be recorded</translation>
     </message>
     <message>
         <location filename="../maaritys/inboxmaaritys.cpp" line="98"/>
         <source>Valitse kansio, jonne kirjatut siirretään</source>
-        <translation type="unfinished"></translation>
+        <translation>Choose the folder where the entries will be transferred</translation>
     </message>
 </context>
 <context>
@@ -3282,12 +3311,12 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../arkisto/jaksottaja.cpp" line="36"/>
         <source>Vahvista tilinpäätösjaksotukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm financial statement accruals</translation>
     </message>
     <message>
         <location filename="../arkisto/jaksottaja.cpp" line="37"/>
         <source>Tilinpäätösjaksotukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statement accruals</translation>
     </message>
 </context>
 <context>
@@ -3295,22 +3324,22 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../maaritys/kaavaeditori.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/kaavaeditori.ui" line="22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tilinpäätöksen mallin muokkaaminen&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Tässä määritellään tilinpäätökseen tulostettavat raportit ja liitetietojen kaava. Katso ohjeet käsikirjasta.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Editing the financial statement template&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Here you define the reports to be printed in the financial statement and the formula for the notes. See the manual for instructions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../maaritys/kaavaeditori.ui" line="49"/>
         <source>&amp;Lisää raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Add report</translation>
     </message>
     <message>
         <location filename="../maaritys/kaavaeditori.ui" line="56"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
 </context>
 <context>
@@ -3318,32 +3347,32 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../aloitussivu/kaksivaihedialog.ui" line="14"/>
         <source>Kitsas</source>
-        <translation type="unfinished"></translation>
+        <translation>Narrow</translation>
     </message>
     <message>
         <location filename="../aloitussivu/kaksivaihedialog.ui" line="39"/>
         <source>Kaksivaiheinen tunnistautuminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Two-factor authentication</translation>
     </message>
     <message>
         <location filename="../aloitussivu/kaksivaihedialog.ui" line="46"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../aloitussivu/kaksivaihedialog.ui" line="53"/>
         <source>Syötä kuusinumeroinen kertakäyttökoodi puhelimesi tunnistautumissovelluksesta</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter the six-digit one-time code from your phone&apos;s authentication app</translation>
     </message>
     <message>
         <location filename="../aloitussivu/kaksivaihedialog.cpp" line="35"/>
         <source>Sähköpostiosoitteen vahvistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address verification</translation>
     </message>
     <message>
         <location filename="../aloitussivu/kaksivaihedialog.cpp" line="37"/>
         <source>Syötä uuteen sähköpostiosoitteeseesi lähetetty kuusinumeroinen vahvistuskoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter the six-digit verification code sent to your new email address</translation>
     </message>
 </context>
 <context>
@@ -3351,224 +3380,224 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="230"/>
         <source>Lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="232"/>
         <source>Käteinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Cash</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="234"/>
         <source>Korttimaksu</source>
-        <translation type="unfinished"></translation>
+        <translation>Card payment</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="236"/>
         <source>Ennakkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Advance invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="237"/>
         <source>Suoriteperusteinen lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Accrual-based invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="238"/>
         <source>Kuukausittainen lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Monthly invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="258"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="260"/>
         <source>Huoneisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Apartment</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="262"/>
         <source>Vakioviite</source>
-        <translation type="unfinished"></translation>
+        <translation>Standard reference</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="263"/>
         <source>Valvomaton</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmonitored</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="300"/>
         <source>Maksettu </source>
-        <translation type="unfinished"></translation>
+        <translation>Paid </translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="309"/>
         <source>Toimitettu %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivered %1</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="250"/>
         <source>Yksittäinen lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Single invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="312"/>
         <source>Lähetetty %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Sent %1</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="526"/>
         <source>Tulosta lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Print invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="535"/>
         <source>Postita lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Mail invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="542"/>
         <source>Ei voi lähettää verkkolaskuna, koska vastaanottajan postiosoite on puutteellinen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Cannot be sent as an e-invoice because the recipient&apos;s postal address is incomplete.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="545"/>
         <source>Verkkolaskutuksen käyttöönotto on kesken.</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoicing implementation is in progress.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="547"/>
         <source>Muokattua laskua ei voi lähettää verkkolaskuna. Laadi tarvittaessa hyvityslasku.</source>
-        <translation type="unfinished"></translation>
+        <translation>A modified invoice cannot be sent as an e-invoice. Create a credit invoice if necessary.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="550"/>
         <source>Verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="558"/>
         <source>Lähetä sähköpostilla</source>
-        <translation type="unfinished"></translation>
+        <translation>Send by email</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="560"/>
         <source>Tallenna pdf-tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Save as PDF file</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="561"/>
         <source>Ei tulosteta</source>
-        <translation type="unfinished"></translation>
+        <translation>Not printed</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="583"/>
         <source>Tallenna ja lähetä sähköpostilla</source>
-        <translation type="unfinished"></translation>
+        <translation>Save and send by email</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="587"/>
         <source>Tallenna ja toimita</source>
-        <translation type="unfinished"></translation>
+        <translation>Save and deliver</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="590"/>
         <source>Tallenna reskontraan</source>
-        <translation type="unfinished"></translation>
+        <translation>Save to accounts receivable</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="593"/>
         <source>Tallenna ja postita</source>
-        <translation type="unfinished"></translation>
+        <translation>Save and mail</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="596"/>
         <source>Tallenna ja lähetä</source>
-        <translation type="unfinished"></translation>
+        <translation>Save and send</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="599"/>
         <source>Tallenna ja tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Save and print</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="634"/>
         <source>Laskut ajalla</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoices for the period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="634"/>
         <source>Toimituspäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivery date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="726"/>
         <source>Puuttuva toimituspäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Missing delivery date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="726"/>
         <source>Suoritusperusteiselle laskulle on määriteltä toimituspäivä, koska suoritusperusteinen lasku kirjataan kirjanpitoon toimituspäivän mukaisesti.</source>
-        <translation type="unfinished"></translation>
+        <translation>An accrual-based invoice must have a delivery date specified, because an accrual-based invoice is recorded in the accounting according to the delivery date.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="731"/>
         <source>Lukittu tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Locked accounting period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="731"/>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="736"/>
         <source>Toimituspäivämäärälle ei ole avointa tilikautta</source>
-        <translation type="unfinished"></translation>
+        <translation>There is no open accounting period for the delivery date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="731"/>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="736"/>
         <source>Laskun päivämäärälle ei ole avointa tilikautta</source>
-        <translation type="unfinished"></translation>
+        <translation>There is no open accounting period for the invoice date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="736"/>
         <source>Puuttuva tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Missing accounting period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="742"/>
         <source>Virheellinen toimitusjakso</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid delivery period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="742"/>
         <source>Toimitusjakson päättymispäivä on virheellinen.</source>
-        <translation type="unfinished"></translation>
+        <translation>The end date of the delivery period is invalid.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="811"/>
         <source>Pdf-tiedosto (*.pdf);;Kuvat (*.png *.jpg);;CSV-tiedosto (*.csv);;Kaikki tiedostot (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>PDF file (*.pdf);;Images (*.png *.jpg);;CSV file (*.csv);;All files (*.*)</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="811"/>
         <source>Lisää liite</source>
-        <translation type="unfinished"></translation>
+        <translation>Add attachment</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="821"/>
         <source>Poista liite</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove attachment</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="822"/>
         <source>Poistetaanko liite %1. Poistettua liitettä ei voi palauttaa!</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to delete attachment %1. A deleted attachment cannot be restored!</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/kantalaskudialogi.cpp" line="849"/>
         <source>Lasku %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice %1</translation>
     </message>
 </context>
 <context>
@@ -3576,67 +3605,67 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="25"/>
         <source>Kirjanpidon käyttöoikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="37"/>
         <source>Lisää käyttäjä</source>
-        <translation type="unfinished"></translation>
+        <translation>Add user</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="50"/>
         <source>Lisättävän käyttäjän sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address of the user to be added</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="74"/>
         <source>Lisää</source>
-        <translation type="unfinished"></translation>
+        <translation>Add</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="88"/>
         <source>Kutsu</source>
-        <translation type="unfinished"></translation>
+        <translation>Invite</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="139"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="146"/>
         <source>osoite@fi</source>
-        <translation type="unfinished"></translation>
+        <translation>address@fi</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="153"/>
         <source>Kirjanpidon omistaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting owner</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="174"/>
         <source>Poista oikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="185"/>
         <source>Kaikki oikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>All permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="209"/>
         <source>Lähetä kutsu uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Resend invitation</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeudet.ui" line="223"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
 </context>
 <context>
@@ -3644,12 +3673,12 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeussivu.cpp" line="162"/>
         <source>Käyttäjän oikeudet tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>User permissions saved</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kayttooikeussivu.cpp" line="201"/>
         <source>Kutsuviesti lähetetty sähköpostiin</source>
-        <translation type="unfinished"></translation>
+        <translation>Invitation message sent to email</translation>
     </message>
 </context>
 <context>
@@ -3658,19 +3687,19 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
         <location filename="../laskutus/ryhmalasku/kielidelegaatti.cpp" line="50"/>
         <location filename="../laskutus/ryhmalasku/kielidelegaatti.cpp" line="62"/>
         <source>suomi</source>
-        <translation type="unfinished"></translation>
+        <translation>Finnish</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/kielidelegaatti.cpp" line="51"/>
         <location filename="../laskutus/ryhmalasku/kielidelegaatti.cpp" line="58"/>
         <source>ruotsi</source>
-        <translation type="unfinished"></translation>
+        <translation>Swedish</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/kielidelegaatti.cpp" line="52"/>
         <location filename="../laskutus/ryhmalasku/kielidelegaatti.cpp" line="60"/>
         <source>englanti</source>
-        <translation type="unfinished"></translation>
+        <translation>English</translation>
     </message>
 </context>
 <context>
@@ -3678,53 +3707,53 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../kierto/kierto.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="64"/>
         <source>Siirrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Move</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="100"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="161"/>
         <source>Vastaanotto</source>
-        <translation type="unfinished"></translation>
+        <translation>Reception</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="216"/>
         <source>Aloita kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>Start circulation</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="243"/>
         <source>Tarkastus</source>
-        <translation type="unfinished"></translation>
+        <translation>Inspection</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="311"/>
         <source>Tarkasta</source>
-        <translation type="unfinished"></translation>
+        <translation>Check</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="322"/>
         <location filename="../kierto/kierto.ui" line="428"/>
         <source>Hylkää</source>
-        <translation type="unfinished"></translation>
+        <translation>Reject</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="349"/>
         <source>Hyväksyntä</source>
-        <translation type="unfinished"></translation>
+        <translation>Approval</translation>
     </message>
     <message>
         <location filename="../kierto/kierto.ui" line="417"/>
         <source>Hyväksy</source>
-        <translation type="unfinished"></translation>
+        <translation>Approve</translation>
     </message>
 </context>
 <context>
@@ -3732,88 +3761,89 @@ Voit lähettää sen verottajalle ilmoitin.fi-palvelulla.</source>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="26"/>
         <source>Laskujen kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice circulation</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="33"/>
         <source>Määritellyt kierrot</source>
-        <translation type="unfinished"></translation>
+        <translation>Defined circulations</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="44"/>
         <source>Uusi</source>
-        <translation type="unfinished"></translation>
+        <translation>New</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="58"/>
         <source>Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="72"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="101"/>
         <source>Laskutusportaali</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing portal</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="113"/>
         <source>Yhtään kiertoa ei ole määritelty näkyväksi portaalissa.</source>
-        <translation type="unfinished"></translation>
+        <translation>No circulations have been defined to be visible in the portal.</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="122"/>
         <source>Osoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Address</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="142"/>
         <source>Oma
 ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Own
+guide</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="156"/>
         <source>Käytä tekstintunnistusta</source>
-        <translation type="unfinished"></translation>
+        <translation>Use text recognition</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="184"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.ui" line="195"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.cpp" line="98"/>
         <source>Verkkomaksujen kierron poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Removing online payment circulation</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.cpp" line="99"/>
         <source>Tämä kierto on verkkolaskujen vastaanottamista varten, eikä sitä voi poistaa.</source>
-        <translation type="unfinished"></translation>
+        <translation>This circulation is for receiving e-invoices and cannot be deleted.</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.cpp" line="103"/>
         <source>Kierron poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove cycle</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomaaritys.cpp" line="104"/>
         <source>Haluatko todella poistaa kierron %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to remove cycle %1</translation>
     </message>
 </context>
 <context>
@@ -3821,102 +3851,102 @@ ohje</source>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="14"/>
         <source>Kierron muokkaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit cycle</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="22"/>
         <source>Kierron nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Cycle name</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="38"/>
         <source>Näkyvillä laskutusportaalissa</source>
-        <translation type="unfinished"></translation>
+        <translation>Visible in billing portal</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="47"/>
         <source>Tyyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="60"/>
         <source>Tiliöinti</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="73"/>
         <source>Vastatili</source>
-        <translation type="unfinished"></translation>
+        <translation>Contra account</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="86"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="102"/>
         <source>Lisää osallistuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Add participant</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="114"/>
         <source>Lähetä sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Send email</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="121"/>
         <source>Lisää</source>
-        <translation type="unfinished"></translation>
+        <translation>Add</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="135"/>
         <source>Osallistujat</source>
-        <translation type="unfinished"></translation>
+        <translation>Participants</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.ui" line="172"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="91"/>
         <source>Kululasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Expense invoice</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="92"/>
         <source>Ostolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Purchase invoice</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="93"/>
         <source>Verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="94"/>
         <source>Tulotosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Income voucher</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="120"/>
         <source>Uusi kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>New cycle</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="154"/>
         <source>Saapunut</source>
-        <translation type="unfinished"></translation>
+        <translation>Arrived</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="156"/>
         <source>Tarkastettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Checked</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausdlg.cpp" line="158"/>
         <source>Hyväksytty</source>
-        <translation type="unfinished"></translation>
+        <translation>Approved</translation>
     </message>
 </context>
 <context>
@@ -3924,22 +3954,22 @@ ohje</source>
     <message>
         <location filename="../kierto/kiertomuokkausmodel.cpp" line="31"/>
         <source>Osallistuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Participant</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausmodel.cpp" line="32"/>
         <source>Vaiheen jälkeen</source>
-        <translation type="unfinished"></translation>
+        <translation>After phase</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausmodel.cpp" line="76"/>
         <source>Sähköpostilla</source>
-        <translation type="unfinished"></translation>
+        <translation>By email</translation>
     </message>
     <message>
         <location filename="../kierto/kiertomuokkausmodel.cpp" line="33"/>
         <source>Ilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Notification</translation>
     </message>
 </context>
 <context>
@@ -3947,42 +3977,42 @@ ohje</source>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="33"/>
         <source>Tila</source>
-        <translation type="unfinished"></translation>
+        <translation>Status</translation>
     </message>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="34"/>
         <source>Kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>Circulation</translation>
     </message>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="35"/>
         <source>Pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="36"/>
         <source>Eräpäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Due date</translation>
     </message>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="37"/>
         <source>Summa</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount</translation>
     </message>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="38"/>
         <source>Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Supplier</translation>
     </message>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="39"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../kierto/kiertoselausmodel.cpp" line="81"/>
         <source>Lasku %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice %1</translation>
     </message>
 </context>
 <context>
@@ -3990,17 +4020,17 @@ ohje</source>
     <message>
         <location filename="../kierto/kiertosivu.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../kierto/kiertosivu.cpp" line="33"/>
         <source>Työlista</source>
-        <translation type="unfinished"></translation>
+        <translation>Work list</translation>
     </message>
     <message>
         <location filename="../kierto/kiertosivu.cpp" line="34"/>
         <source>Kaikki</source>
-        <translation type="unfinished"></translation>
+        <translation>All</translation>
     </message>
 </context>
 <context>
@@ -4009,7 +4039,8 @@ ohje</source>
         <location filename="../kierto/kiertowidget.cpp" line="227"/>
         <source>puh. %1 
 </source>
-        <translation type="unfinished"></translation>
+        <translation>tel. %1 
+</translation>
     </message>
     <message>
         <location filename="../kierto/kiertowidget.cpp" line="228"/>
@@ -4019,7 +4050,7 @@ ohje</source>
         <location filename="../kierto/kiertowidget.cpp" line="255"/>
         <location filename="../kierto/kiertowidget.cpp" line="265"/>
         <source>dd.MM.yyyy klo hh.mm</source>
-        <translation type="unfinished"></translation>
+        <translation>dd.MM.yyyy at hh.mm</translation>
     </message>
 </context>
 <context>
@@ -4027,12 +4058,12 @@ ohje</source>
     <message>
         <location filename="../tilaus/kiitos.ui" line="14"/>
         <source>Tilaus vastaanotettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Order received</translation>
     </message>
     <message>
         <location filename="../tilaus/kiitos.ui" line="55"/>
         <source>Kiitos tilauksesta</source>
-        <translation type="unfinished"></translation>
+        <translation>Thank you for your order</translation>
     </message>
     <message>
         <location filename="../tilaus/kiitos.ui" line="65"/>
@@ -4040,7 +4071,10 @@ ohje</source>
 
 Tilaamasi ominaisuudet ovat välittömästi käytettävissäsi.
 Jos Sinulle tulee kysyttävää, älä epäröi ottaa yhteyttä ystävälliseen käyttäjätukeemme.</source>
-        <translation type="unfinished"></translation>
+        <translation>As a paying customer, you ensure the continued development of Kitsas. You get access to additional features and can save your accounting to the cloud service.
+
+The features you have ordered are immediately available to you.
+If you have any questions, don&apos;t hesitate to contact our friendly user support.</translation>
     </message>
 </context>
 <context>
@@ -4048,51 +4082,55 @@ Jos Sinulle tulee kysyttävää, älä epäröi ottaa yhteyttä ystävälliseen 
     <message>
         <location filename="../db/kirjanpito.cpp" line="118"/>
         <source>Tilapäishakemiston luominen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create temporary directory</translation>
     </message>
     <message>
         <location filename="../db/kirjanpito.cpp" line="119"/>
         <source>Kitsas ei onnistunut luomaan tilapäishakemistoa. Raporttien ja laskujen esikatselu ei toimi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas failed to create a temporary directory. Preview of reports and invoices is not working.</translation>
     </message>
     <message>
         <location filename="../db/kirjanpito.cpp" line="174"/>
         <source>Ohjeen näyttäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to display help</translation>
     </message>
     <message>
         <location filename="../db/kirjanpito.cpp" line="175"/>
         <source>Kitsas ei saanut käynnistettyä selainta ohjeen näyttämiseksi. Onhan järjestelmässäsi määritelty oletusselain avaamaan internet-sivuja?
 
 Ohjelman ohjeet löytyvät %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas couldn&apos;t launch the browser to display the help. Is a default browser set in your system to open web pages?
+
+Program instructions can be found at %1</translation>
     </message>
     <message>
         <location filename="../db/kirjanpito.cpp" line="192"/>
         <source>Selaimen käynnistäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to launch browser</translation>
     </message>
     <message>
         <location filename="../db/kirjanpito.cpp" line="193"/>
         <source>Kitsas ei saanut käynnistettyä selainta tiedoston %1 näyttämiseksi. Onhan järjestelmässäsi määritelty oletusselain avaamaan internet-sivuja?
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas was unable to launch a browser to display the file %1. Is a default browser set in your system to open internet pages?
+
+</translation>
     </message>
     <message>
         <location filename="../db/kirjanpito.cpp" line="196"/>
         <source>Tiedoston näyttäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to display the file</translation>
     </message>
     <message>
         <location filename="../db/kirjanpito.cpp" line="197"/>
         <source>Kitsas ei saanut käynnistettyä ulkoista ohjelmaa tiedoston %1 näyttämiseksi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas failed to launch an external program to display file %1.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/aloitusinfo.cpp" line="33"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
 </context>
 <context>
@@ -4100,7 +4138,7 @@ Ohjelman ohjeet löytyvät %1</source>
     <message>
         <location filename="../kirjaus/kirjaussivu.cpp" line="98"/>
         <source>Nykyistä kirjausta on muokattu. Poistutko sivulta tallentamatta tekemiäsi muutoksia?</source>
-        <translation type="unfinished"></translation>
+        <translation>The current entry has been modified. Do you want to leave the page without saving your changes?</translation>
     </message>
 </context>
 <context>
@@ -4108,398 +4146,407 @@ Ohjelman ohjeet löytyvät %1</source>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="22"/>
         <source>Tositet&amp;yyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher &amp;type</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="47"/>
         <source>Tositteen &amp;pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher &amp;date</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="60"/>
         <source>&amp;Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Title</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="92"/>
         <source>&amp;Viennit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Entries</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="133"/>
         <source>Lisää uusi vientirivi F11</source>
-        <translation type="unfinished"></translation>
+        <translation>Add new entry row F11</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="136"/>
         <source>Lisää rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Add row</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="504"/>
         <source>Ctrl+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="150"/>
         <source>Lisää vienti valintataululla</source>
-        <translation type="unfinished"></translation>
+        <translation>Add entry with selection panel</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="153"/>
         <source>Lisää vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>Add entry</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="167"/>
         <source>Muokkaa vientiä</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit entry</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="181"/>
         <source>Poista rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete row</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="188"/>
         <source>Del</source>
-        <translation type="unfinished"></translation>
+        <translation>Del</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="202"/>
         <source>&amp;Muistiinpanot</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Notes</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="208"/>
         <source>Kirjoita tähän tositteeseen liittyvät muistiinpanot</source>
-        <translation type="unfinished"></translation>
+        <translation>Write notes related to this document here</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="220"/>
         <source>L&amp;iitteet</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;ttachments</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="250"/>
         <source>Avaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="272"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="296"/>
         <source>Li&amp;sää</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;dd</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="143"/>
         <location filename="../kirjaus/kirjaus.ui" line="303"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="310"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="328"/>
         <source>&amp;Varasto</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Inventory</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="337"/>
         <source>Loki</source>
-        <translation type="unfinished"></translation>
+        <translation>Log</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="377"/>
         <source>Tekninen tunniste</source>
-        <translation type="unfinished"></translation>
+        <translation>Technical identifier</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="384"/>
         <source>0</source>
-        <translation type="unfinished"></translation>
+        <translation>0</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="399"/>
         <source>Tositesarja</source>
-        <translation type="unfinished"></translation>
+        <translation>Document series</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="426"/>
         <source>Alt+Left</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt+Left</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="456"/>
         <source>Alt+Right</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt+Right</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="470"/>
         <source>Asettaa huomiomerkin</source>
-        <translation type="unfinished"></translation>
+        <translation>Set attention mark</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="473"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="481"/>
         <source>Ctrl+H</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+H</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="494"/>
         <source>Tallenna tosite Ctrl+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Save voucher Ctrl+S</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="497"/>
         <source>Tallenna luonnos</source>
-        <translation type="unfinished"></translation>
+        <translation>Save draft</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="544"/>
         <source>Tekstintunnistus...</source>
-        <translation type="unfinished"></translation>
+        <translation>Text recognition...</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="554"/>
         <source>Tallennetaan...</source>
-        <translation type="unfinished"></translation>
+        <translation>Saving...</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="577"/>
         <source>Tallenna valmiina    F12</source>
-        <translation type="unfinished"></translation>
+        <translation>Save as completed    F12</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="580"/>
         <source>Valmis</source>
-        <translation type="unfinished"></translation>
+        <translation>Ready</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="587"/>
         <source>F12</source>
-        <translation type="unfinished"></translation>
+        <translation>F12</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="600"/>
         <source>Hylkää muutokset Esc</source>
-        <translation type="unfinished"></translation>
+        <translation>Discard changes Esc</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="603"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="610"/>
         <source>Esc</source>
-        <translation type="unfinished"></translation>
+        <translation>Esc</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="125"/>
         <source>Siirry tositteeseen	Ctrl+G</source>
-        <translation type="unfinished"></translation>
+        <translation>Go to voucher	Ctrl+G</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="127"/>
         <source>Tulosta tosite	Ctrl+P</source>
-        <translation type="unfinished"></translation>
+        <translation>Print voucher	Ctrl+P</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="128"/>
         <source>Kopioi uuden pohjaksi	Ctrl+T</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy as new template	Ctrl+T</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="129"/>
         <source>Tallenna mallipohjaksi</source>
-        <translation type="unfinished"></translation>
+        <translation>Save as template</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="130"/>
         <source>Poista tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="132"/>
         <source>Tyhjennä viennit</source>
-        <translation type="unfinished"></translation>
+        <translation>Clear entries</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="133"/>
         <source>Vaihda tunnistenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Change identification number</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="287"/>
         <source>Tositteen tallentaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Saving the voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="288"/>
         <source>Tositteessa ei ole yhtään vientiä.
 Tallennatko tositteen ilman vientejä?</source>
-        <translation type="unfinished"></translation>
+        <translation>The voucher has no entries.
+Do you want to save the voucher without entries?</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="295"/>
         <source>Arvonlisäveron kirjaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Value Added Tax entries</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="296"/>
         <source>Arvonlisäveron kirjauksissa on todennäköisesti virhe.
 Tallennetaanko tosite silti?
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>There is likely an error in the Value Added Tax entries.
+Do you still want to save the voucher?
+%1</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="485"/>
         <source>Debet %1    Kredit %2    &lt;b&gt;Erotus %3&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit %1    Credit %2    &lt;b&gt;Difference %3&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="782"/>
         <source>Keskeytä kirjaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel entry</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="784"/>
         <source>Haluatko keskeyttää kirjauksen tallentamatta tositetta?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to cancel the entry without saving the voucher?</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="785"/>
         <source>Haluatko keskeyttää kirjauksen tallentamatta muutoksia?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to cancel the entry without saving changes?</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="317"/>
         <source>Tositteen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Deleting the voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="318"/>
         <source>Haluatko todella poistaa tämän tositteen?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to delete this voucher?</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="322"/>
         <source>Tietokantavirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Database error</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="323"/>
         <source>Tietokantavirhe tositetta poistettaessa
 
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Database error while deleting the voucher
+
+%1</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjaus.ui" line="261"/>
         <location filename="../kirjaus/kirjauswg.cpp" line="424"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="473"/>
         <source>Kirjanpidossa ei ole
 avointa tilikautta.</source>
-        <translation type="unfinished"></translation>
+        <translation>There is no
+open accounting period in the bookkeeping.</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="477"/>
         <source>Kirjanpito lukittu
 %1 saakka</source>
-        <translation type="unfinished"></translation>
+        <translation>Bookkeeping locked
+until %1</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="482"/>
         <source>Alv-ilmoitus on jo annettu</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT return has already been submitted</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="492"/>
         <source>Päivämäärälle ei ole
 tilikautta kirjanpidossa.</source>
-        <translation type="unfinished"></translation>
+        <translation>There is no accounting period
+for the date in the bookkeeping.</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="494"/>
         <source>Tiliöintejä puuttuu</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting entries are missing</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="497"/>
         <source>Päivämääriä puuttuu</source>
-        <translation type="unfinished"></translation>
+        <translation>Dates are missing</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="500"/>
         <source>Debet ja kredit eivät täsmää jokaisella päivämäärällä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit and credit do not match on every date.</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="502"/>
         <source>Summa %L1 €</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount %L1 €</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="578"/>
         <source>Tallennus epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Saving failed</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="578"/>
         <source>Tositteen tallentaminen epäonnistui (Virhe %1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save the voucher (Error %1)</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="630"/>
         <source>Kommentit</source>
-        <translation type="unfinished"></translation>
+        <translation>Comments</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="648"/>
         <source>Valitse tositenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Select voucher number</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="648"/>
         <source>Uusi tositenumero:
 Ohjelma ei tarkasta tositenumeroa!</source>
-        <translation type="unfinished"></translation>
+        <translation>New voucher number:
+The program does not check the voucher number!</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="664"/>
         <source>Kitsas</source>
-        <translation type="unfinished"></translation>
+        <translation>Narrow</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="664"/>
         <source>Nykyistä kirjausta on muokattu. Siirrytkö toiseen tositteeseen tallentamatta tekemiäsi muutoksia?</source>
-        <translation type="unfinished"></translation>
+        <translation>The current entry has been modified. Do you want to move to another voucher without saving your changes?</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="766"/>
         <source>Tosite saattaa olla jo kirjattu</source>
-        <translation type="unfinished"></translation>
+        <translation>The voucher may have already been recorded</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="767"/>
@@ -4507,42 +4554,45 @@ Ohjelma ei tarkasta tositenumeroa!</source>
 
 %1 
 Tallennetaanko tosite silti?</source>
-        <translation type="unfinished"></translation>
+        <translation>A similar voucher already exists in the accounting 
+
+%1 
+Do you still want to save the voucher?</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="806"/>
         <source>Valitse tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Select voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="806"/>
         <source>Pdf-tiedostot (*.pdf);;Kuvat (*.png *.jpg);;Csv-tiedosto (*.csv);;Kaikki tiedostot (*)</source>
-        <translation type="unfinished"></translation>
+        <translation>PDF files (*.pdf);;Images (*.png *.jpg);;CSV file (*.csv);;All files (*)</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="939"/>
         <source>Kirjaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Record</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="961"/>
         <source>Uusi tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>New voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="999"/>
         <source>Kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>Circulation</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="1027"/>
         <source>Poista liite</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove attachment</translation>
     </message>
     <message>
         <location filename="../kirjaus/kirjauswg.cpp" line="1028"/>
         <source>Poistetaanko liite %1. Poistettua liitettä ei voi palauttaa!</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to delete attachment %1. A deleted attachment cannot be restored!</translation>
     </message>
 </context>
 <context>
@@ -4550,17 +4600,17 @@ Tallennetaanko tosite silti?</source>
     <message>
         <location filename="../tools/kitsaslokimodel.cpp" line="103"/>
         <source>Tiedosto</source>
-        <translation type="unfinished"></translation>
+        <translation>File</translation>
     </message>
     <message>
         <location filename="../tools/kitsaslokimodel.cpp" line="104"/>
         <source>Rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Line</translation>
     </message>
     <message>
         <location filename="../tools/kitsaslokimodel.cpp" line="105"/>
         <source>Viesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Message</translation>
     </message>
 </context>
 <context>
@@ -4568,175 +4618,176 @@ Tallennetaanko tosite silti?</source>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="156"/>
         <source>Kirjaa uudessa ikkunassa	Ctrl + W</source>
-        <translation type="unfinished"></translation>
+        <translation>Record in a new window	Ctrl + W</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="160"/>
         <source>Selaa uudessa ikkunassa	Shift+F3</source>
-        <translation type="unfinished"></translation>
+        <translation>Browse in new window	Shift+F3</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="164"/>
         <source>Uusi lasku	Shift+F4</source>
-        <translation type="unfinished"></translation>
+        <translation>New invoice	Shift+F4</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="260"/>
         <source>Kitsas %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas %1</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="509"/>
         <source>Valikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Menu</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="532"/>
         <source>Aloita</source>
-        <translation type="unfinished"></translation>
+        <translation>Start</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="532"/>
         <source>Erilaisia ohjattuja toimia</source>
-        <translation type="unfinished"></translation>
+        <translation>Various guided actions</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="533"/>
         <source>Uusi 
 tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>New 
+document</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="533"/>
         <source>Kirjaa uusi tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Record a new document</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="534"/>
         <source>Selaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Browse</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="534"/>
         <source>Selaa kirjauksia aikajärjestyksessä</source>
-        <translation type="unfinished"></translation>
+        <translation>Browse entries in chronological order</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="535"/>
         <source>Kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>Circulation</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="535"/>
         <source>Käsittele kierrossa olevia laskuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Process invoices in circulation</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="536"/>
         <source>Laskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoices</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="536"/>
         <source>Laskuta ja selaa laskuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice and browse invoices</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="537"/>
         <source>Raportit</source>
-        <translation type="unfinished"></translation>
+        <translation>Reports</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="537"/>
         <source>Tulosta erilaisia raportteja</source>
-        <translation type="unfinished"></translation>
+        <translation>Print various reports</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="538"/>
         <source>Tilikaudet</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting periods</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="538"/>
         <source>Tilinpäätös ja arkistot</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statements and archives</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="539"/>
         <source>ALV</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="539"/>
         <source>Arvonlisäveron ilmoittaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Value Added Tax reporting</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="540"/>
         <source>Asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="540"/>
         <source>Kirjanpitoon liittyvät määritykset</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting-related configurations</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="541"/>
         <source>Lisäosat</source>
-        <translation type="unfinished"></translation>
+        <translation>Add-ons</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="541"/>
         <source>Lisäosien hallinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Add-on management</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="542"/>
         <source>Toimisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Office</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="542"/>
         <location filename="../kitupiikkiikkuna.cpp" line="543"/>
         <source>Tilitoimistojen käyttäjien ja kirjanpitojen hallinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Management of accounting firm users and accounts</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="543"/>
         <source>Majava</source>
-        <translation type="unfinished"></translation>
+        <translation>Beaver</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="555"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="568"/>
         <source>Voit nopeuttaa ajan kulumista</source>
-        <translation type="unfinished"></translation>
+        <translation>You can speed up the passage of time</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="568"/>
         <source>Harjoittelutila käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Practice mode enabled</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="238"/>
         <location filename="../kitupiikkiikkuna.cpp" line="583"/>
         <source>Harjoittelu</source>
-        <translation type="unfinished"></translation>
+        <translation>Practice</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="240"/>
         <source>%1 - %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2 %3</translation>
     </message>
     <message>
         <location filename="../kitupiikkiikkuna.cpp" line="599"/>
         <source>Kirjattavat</source>
-        <translation type="unfinished"></translation>
+        <translation>Items to be recorded</translation>
     </message>
 </context>
 <context>
@@ -4744,32 +4795,32 @@ tosite</source>
     <message>
         <location filename="../maaritys/kohdennukset.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennukset.ui" line="26"/>
         <source>Kohdennukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocations</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennukset.ui" line="48"/>
         <source>Uusi</source>
-        <translation type="unfinished"></translation>
+        <translation>New</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennukset.ui" line="55"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennukset.ui" line="65"/>
         <source>Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennukset.ui" line="79"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
@@ -4777,52 +4828,52 @@ tosite</source>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="14"/>
         <source>Kohdennuksen muokkaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit allocation</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="20"/>
         <source>Kohdennuksen tyyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation type</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="40"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Kustannuspaikka&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kustannuspaikkoja voivat olla osastot, jaostot, toiminnot tai yksittäiset tapahtumat.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Cost center&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Cost centers can be departments, sections, functions, or individual events.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="61"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Projekti&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Muodostamalla projektin voit eritellä kustannuksia vielä kustannuspaikkoja tarkemmin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Project&lt;/span&gt;&lt;/p&gt;&lt;p&gt;By creating a project, you can itemize costs even more precisely than with cost centers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="82"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Merkkaus&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Merkkaamalla viennit voidaan merkitä poimittaviksi omalle luettelolleen. Toimintoa voidaan käyttää erilaisten &amp;quot;korvamerkattujen&amp;quot; erien kuten avustusten seuraamiseen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Marking&lt;/span&gt;&lt;/p&gt;&lt;p&gt;By marking entries, they can be tagged for inclusion in their own list. This function can be used to track various &amp;quot;earmarked&amp;quot; items such as grants.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="97"/>
         <source>Kohdennuksen nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation name</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="104"/>
         <source>Määräaikainen</source>
-        <translation type="unfinished"></translation>
+        <translation>Temporary</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="118"/>
         <source>Alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Starts</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="128"/>
         <source>Päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>Ends</translation>
     </message>
     <message>
         <location filename="../maaritys/kohdennusdialog.ui" line="145"/>
         <source>Kustannuspaikka</source>
-        <translation type="unfinished"></translation>
+        <translation>Cost center</translation>
     </message>
 </context>
 <context>
@@ -4830,13 +4881,14 @@ tosite</source>
     <message>
         <location filename="../db/kohdennusmodel.cpp" line="232"/>
         <source>Virhe tallentamisessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Error in saving</translation>
     </message>
     <message>
         <location filename="../db/kohdennusmodel.cpp" line="232"/>
         <source>Kohdennuksen tallentaminen epäonnistui.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save allocation.
+%1</translation>
     </message>
 </context>
 <context>
@@ -4844,12 +4896,12 @@ tosite</source>
     <message>
         <location filename="../kirjaus/kommentitwidget.cpp" line="39"/>
         <source>Kirjoita lisättävä kommentti tähän</source>
-        <translation type="unfinished"></translation>
+        <translation>Write the comment to be added here</translation>
     </message>
     <message>
         <location filename="../kirjaus/kommentitwidget.cpp" line="40"/>
         <source>Kommentoi</source>
-        <translation type="unfinished"></translation>
+        <translation>Comment</translation>
     </message>
 </context>
 <context>
@@ -4857,17 +4909,17 @@ tosite</source>
     <message>
         <location filename="../raportti/kooste/koosteraporttilistamodel.cpp" line="16"/>
         <source>Ajalta</source>
-        <translation type="unfinished"></translation>
+        <translation>For the period</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/koosteraporttilistamodel.cpp" line="17"/>
         <source>Laatinut</source>
-        <translation type="unfinished"></translation>
+        <translation>Prepared by</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/koosteraporttilistamodel.cpp" line="18"/>
         <source>Lähetetty</source>
-        <translation type="unfinished"></translation>
+        <translation>Sent</translation>
     </message>
 </context>
 <context>
@@ -4875,22 +4927,22 @@ tosite</source>
     <message>
         <location filename="../kirjaus/kopioitosite.ui" line="14"/>
         <source>Tositteen kopiointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying the voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/kopioitosite.ui" line="24"/>
         <source>Päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../kirjaus/kopioitosite.ui" line="31"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../kirjaus/kopioitosite.ui" line="67"/>
         <source>Säilytä tase-erät</source>
-        <translation type="unfinished"></translation>
+        <translation>Retain balance sheet items</translation>
     </message>
 </context>
 <context>
@@ -4899,7 +4951,7 @@ tosite</source>
         <location filename="../tools/kpdateedit.cpp" line="44"/>
         <source>pp.kk.vvvv</source>
         <comment>Päivämääräsyötön placeholder</comment>
-        <translation type="unfinished"></translation>
+        <translation>dd.mm.yyyy</translation>
     </message>
 </context>
 <context>
@@ -4907,164 +4959,164 @@ tosite</source>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="41"/>
         <source>Tuo</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="55"/>
         <source>Vie</source>
-        <translation type="unfinished"></translation>
+        <translation>Export</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="66"/>
         <source>Laskuta</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="90"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="114"/>
         <source>Uusi</source>
-        <translation type="unfinished"></translation>
+        <translation>New</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="125"/>
         <source>Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="136"/>
         <source>Yhdistä</source>
-        <translation type="unfinished"></translation>
+        <translation>Combine</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.ui" line="147"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="228"/>
         <source>Tuotteen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete product</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="228"/>
         <source>Haluatko varmasti poistaa tuotteen?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the product?</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="167"/>
         <source>Uusi ryhmä</source>
-        <translation type="unfinished"></translation>
+        <translation>New group</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="167"/>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="199"/>
         <source>Ryhmän nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Group name</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="199"/>
         <source>Muokkaa ryhmää</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit group</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="232"/>
         <source>Ryhmän poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete group</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="232"/>
         <source>Haluatko varmasti poistaa ryhmän?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the group?</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="240"/>
         <source>Vakioviitteen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete standard reference</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="240"/>
         <source>Haluatko varmasti poistaa vakioviitteen?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the standard reference?</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="247"/>
         <source>Huoneiston poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete apartment</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="247"/>
         <source>Haluatko varmasti poistaa huoneiston?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the apartment?</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="296"/>
         <source>Tuonti csv-tiedostosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Import from CSV file</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="297"/>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="314"/>
         <source>Csv-tiedostot (*.csv);;Kaikki tiedostot (*)</source>
-        <translation type="unfinished"></translation>
+        <translation>CSV files (*.csv);;All files (*)</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="313"/>
         <source>Vienti csv-tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Export to CSV file</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="320"/>
         <source>Tuoterekisteri viety</source>
-        <translation type="unfinished"></translation>
+        <translation>Product registry exported</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="322"/>
         <source>Tuotteiden vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>Export products</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="323"/>
         <source>Tiedostoon %1 kirjoittaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to write to file %1</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="337"/>
         <source>Asiakkaat</source>
-        <translation type="unfinished"></translation>
+        <translation>Customers</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="338"/>
         <source>Toimittajat</source>
-        <translation type="unfinished"></translation>
+        <translation>Suppliers</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="339"/>
         <source>Rekisteri</source>
-        <translation type="unfinished"></translation>
+        <translation>Registry</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="340"/>
         <source>Ryhmät</source>
-        <translation type="unfinished"></translation>
+        <translation>Groups</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="341"/>
         <source>Vakioviitteet</source>
-        <translation type="unfinished"></translation>
+        <translation>Standard references</translation>
     </message>
     <message>
         <location filename="../laskutus/kumppanituotewidget.cpp" line="342"/>
         <source>Huoneistot</source>
-        <translation type="unfinished"></translation>
+        <translation>Apartments</translation>
     </message>
 </context>
 <context>
@@ -5072,27 +5124,27 @@ tosite</source>
     <message>
         <location filename="../maaritys/kayttooikeudet/kutsudialog.ui" line="14"/>
         <source>Kutsu käyttäjä</source>
-        <translation type="unfinished"></translation>
+        <translation>Invite user</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kutsudialog.ui" line="20"/>
         <source>Kutsuttavalle henkilölle lähetetään sähköpostiviesti, jossa on linkki Kitsaan salasanan asettamiseen. Kun kutsun saaja on asettanut itselleen salasanan, voi hän kirjautua Kitsaaseen.</source>
-        <translation type="unfinished"></translation>
+        <translation>An email will be sent to the invited person with a link to set up their Kitsas password. Once the invitee has set their password, they can log in to Kitsas.</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kutsudialog.ui" line="43"/>
         <source>Kutsuttava käyttäjä</source>
-        <translation type="unfinished"></translation>
+        <translation>User to invite</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kutsudialog.ui" line="49"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/kutsudialog.ui" line="59"/>
         <source>Sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address</translation>
     </message>
 </context>
 <context>
@@ -5100,37 +5152,37 @@ tosite</source>
     <message>
         <location filename="../laskutus/laskualvcombo.cpp" line="35"/>
         <source>Veroton</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax-free</translation>
     </message>
     <message>
         <location filename="../laskutus/laskualvcombo.cpp" line="39"/>
         <source>Rakennuspalvelut</source>
-        <translation type="unfinished"></translation>
+        <translation>Construction services</translation>
     </message>
     <message>
         <location filename="../laskutus/laskualvcombo.cpp" line="42"/>
         <source>Tavaramyynti</source>
-        <translation type="unfinished"></translation>
+        <translation>Goods sale</translation>
     </message>
     <message>
         <location filename="../laskutus/laskualvcombo.cpp" line="43"/>
         <source>Palvelumyynti</source>
-        <translation type="unfinished"></translation>
+        <translation>Service sales</translation>
     </message>
     <message>
         <location filename="../laskutus/laskualvcombo.cpp" line="48"/>
         <source>Voittomarginaalimenettely - käytetyt tavarat</source>
-        <translation type="unfinished"></translation>
+        <translation>Profit margin procedure - used goods</translation>
     </message>
     <message>
         <location filename="../laskutus/laskualvcombo.cpp" line="50"/>
         <source>Voittomarginaalimenettely - keräily- ja antiikkiesineet</source>
-        <translation type="unfinished"></translation>
+        <translation>Profit margin procedure - collectibles and antiques</translation>
     </message>
     <message>
         <location filename="../laskutus/laskualvcombo.cpp" line="49"/>
         <source>Voittomarginaalimenettely - taide-esineet</source>
-        <translation type="unfinished"></translation>
+        <translation>Profit margin procedure - art objects</translation>
     </message>
 </context>
 <context>
@@ -5138,422 +5190,423 @@ tosite</source>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="14"/>
         <source>Lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="28"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="45"/>
         <source>Nimi ja
 osoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Name and
+address</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="81"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="134"/>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="896"/>
         <source>Laskutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="157"/>
         <source>Valvonta</source>
-        <translation type="unfinished"></translation>
+        <translation>Monitoring</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="167"/>
         <source>Toi&amp;mituspäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Deli&amp;very date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="182"/>
         <source> - </source>
-        <translation type="unfinished"></translation>
+        <translation> - </translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="198"/>
         <source>Laskun pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="213"/>
         <source>Maksuaika</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../laskutus/laskudlg/laskudialogi.ui" line="223"/>
-        <source> pv</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment term</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="238"/>
         <source>Eräpäi&amp;vä</source>
-        <translation type="unfinished"></translation>
+        <translation>Due &amp;date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="253"/>
         <source>. päivä</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../laskutus/laskudlg/laskudialogi.ui" line="256"/>
-        <source>kuukauden </source>
-        <translation type="unfinished"></translation>
+        <translation>th day</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="272"/>
         <source>Viivästyskorko</source>
-        <translation type="unfinished"></translation>
+        <translation>Late payment interest</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="282"/>
         <source> %</source>
-        <translation type="unfinished"></translation>
+        <translation> %</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="294"/>
         <source>Asiakkaan viite</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer reference</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="324"/>
         <source>Viite</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="338"/>
         <source>00000</source>
-        <translation type="unfinished"></translation>
+        <translation>00000</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="311"/>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1047"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="348"/>
         <source>Lasku saa viitenumeron vasta kun se tallennetaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>The invoice will receive a reference number only when it is saved.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="414"/>
         <source>Rivit</source>
-        <translation type="unfinished"></translation>
+        <translation>Rows</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="427"/>
         <source>Etsi tuotetta nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Search for product by name</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="444"/>
         <source>Uusi tuote</source>
-        <translation type="unfinished"></translation>
+        <translation>New product</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="493"/>
         <source>Lisää uusi rivi   Ctrl+R</source>
-        <translation type="unfinished"></translation>
+        <translation>Add new row   Ctrl+R</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="496"/>
         <source>Lisää rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Add row</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="503"/>
         <source>Ctrl+R</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+R</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="513"/>
         <source>Näyttää uuden rivin lisäysikkunan  Ctrl+E</source>
-        <translation type="unfinished"></translation>
+        <translation>Show new row addition window  Ctrl+E</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="516"/>
         <source>Uusi rivi...</source>
-        <translation type="unfinished"></translation>
+        <translation>New row...</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="523"/>
         <source>Ctrl+E</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+E</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="533"/>
         <source>Rivin lisätiedot..</source>
-        <translation type="unfinished"></translation>
+        <translation>Row additional information..</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="547"/>
         <source>Poista rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete row</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="572"/>
         <source>Maksumuistutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment reminder</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="580"/>
         <source>Avoin määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Open amount</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="621"/>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="638"/>
         <source>0,00 €</source>
-        <translation type="unfinished"></translation>
+        <translation>0.00 €</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="587"/>
         <source>Maksumuistutuksesta peritään</source>
-        <translation type="unfinished"></translation>
+        <translation>A fee will be charged for the payment reminder</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="120"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
+    </message>
+    <message>
+        <location filename="../laskutus/laskudlg/laskudialogi.ui" line="223"/>
+        <source> pv</source>
+        <translation> day(s)</translation>
+    </message>
+    <message>
+        <location filename="../laskutus/laskudlg/laskudialogi.ui" line="256"/>
+        <source>kuukauden </source>
+        <translation>month&apos;s </translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="597"/>
         <source>Viivästyskorko ajalle</source>
-        <translation type="unfinished"></translation>
+        <translation>Late payment interest for the period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="609"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="671"/>
         <source>Lis&amp;ätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Additional information</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="681"/>
         <source>Tilaaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Subscriber</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="698"/>
         <source>Myyjä</source>
-        <translation type="unfinished"></translation>
+        <translation>Seller</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="715"/>
         <source>Huomautusaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Complaint period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="722"/>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="908"/>
         <source> päivää</source>
-        <translation type="unfinished"></translation>
+        <translation> days</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="736"/>
         <source>Tilauspäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Order date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="749"/>
         <source>Tilaajan tilausnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Subscriber&apos;s order number</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="766"/>
         <source>Sopimusnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Contract number</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="796"/>
         <source>Lisätiedot laskun alussa</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional information at the beginning of the invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="818"/>
         <source>Erittely laskun lopussa</source>
-        <translation type="unfinished"></translation>
+        <translation>Itemization at the end of the invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="830"/>
         <source>Toistuminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Recurrence</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="836"/>
         <source>Luo toimitusjakson päättyessä uusi lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Create a new invoice at the end of the delivery period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="850"/>
         <source>Laskutusjakso</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="862"/>
         <source> kuukautta</source>
-        <translation type="unfinished"></translation>
+        <translation> months</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="917"/>
         <source>ennen edellisen jakson päättymistä</source>
-        <translation type="unfinished"></translation>
+        <translation>before the end of the previous period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="930"/>
         <source>edellisen jakson päättymisen jälkeen</source>
-        <translation type="unfinished"></translation>
+        <translation>after the end of the previous period</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="939"/>
         <source>päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>ends</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="969"/>
         <source>Laskuta hinnaston mukaisesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice according to price list</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="994"/>
         <source>Tallenna muutokset toistumiseen</source>
-        <translation type="unfinished"></translation>
+        <translation>Save changes to recurrence</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1005"/>
         <source>Lopeta toistuvat laskut</source>
-        <translation type="unfinished"></translation>
+        <translation>End recurring invoices</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1039"/>
         <source>Saate</source>
-        <translation type="unfinished"></translation>
+        <translation>Cover letter</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1059"/>
         <source>Sähköpostin viestiosan sisältö</source>
-        <translation type="unfinished"></translation>
+        <translation>Email message content</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1071"/>
         <source>Liitteet</source>
-        <translation type="unfinished"></translation>
+        <translation>Attachments</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1089"/>
         <source>Näytä</source>
-        <translation type="unfinished"></translation>
+        <translation>Show</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1113"/>
         <source>Lisää</source>
-        <translation type="unfinished"></translation>
+        <translation>Add</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1127"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1145"/>
         <source>Loki</source>
-        <translation type="unfinished"></translation>
+        <translation>Log</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1178"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1185"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1195"/>
         <source>Tallenna luonnos   Ctrl+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Save draft   Ctrl+S</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1198"/>
         <source>Tallenna luonnoksena</source>
-        <translation type="unfinished"></translation>
+        <translation>Save as draft</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1205"/>
         <source>Ctrl+S</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+S</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1218"/>
         <source>Tallenna lasku   F11</source>
-        <translation type="unfinished"></translation>
+        <translation>Save invoice   F11</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1221"/>
         <source>T&amp;allenna valmiina</source>
-        <translation type="unfinished"></translation>
+        <translation>S&amp;ave as completed</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1228"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1241"/>
         <source>Näytä lasku  F5</source>
-        <translation type="unfinished"></translation>
+        <translation>Show invoice  F5</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1244"/>
         <source>Nä&amp;ytä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Show</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1251"/>
         <source>F5</source>
-        <translation type="unfinished"></translation>
+        <translation>F5</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1274"/>
         <source>Hyvitä ennakko</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit advance</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1324"/>
         <source>Tallenna ja toimita   F12</source>
-        <translation type="unfinished"></translation>
+        <translation>Save and deliver   F12</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1330"/>
         <source>Tallenna ja tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Save and print</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1337"/>
         <source>F12</source>
-        <translation type="unfinished"></translation>
+        <translation>F12</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1347"/>
         <source>Poistu tallentamatta</source>
-        <translation type="unfinished"></translation>
+        <translation>Exit without saving</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskudialogi.ui" line="1350"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
 </context>
 <context>
@@ -5561,12 +5614,12 @@ osoite</source>
     <message>
         <location filename="../raportti/laskuraportti.cpp" line="121"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.cpp" line="123"/>
         <source>Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Supplier</translation>
     </message>
 </context>
 <context>
@@ -5574,141 +5627,141 @@ osoite</source>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="14"/>
         <source>Laskurivin tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice line details</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="96"/>
         <source>Toimituspäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivery date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="102"/>
         <source>Alkupäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Start date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="109"/>
         <source>Loppupäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>End date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="266"/>
         <source>Alennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Discount</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="272"/>
         <source>Prosentti</source>
-        <translation type="unfinished"></translation>
+        <translation>Percentage</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="194"/>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="289"/>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="328"/>
         <source>Veroton</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax-free</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="299"/>
         <source>Syy</source>
-        <translation type="unfinished"></translation>
+        <translation>Reason</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="204"/>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="309"/>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="338"/>
         <source>Verollinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Taxable</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="45"/>
         <source>Tuotetiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Product information</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="51"/>
         <source>Nimike</source>
-        <translation type="unfinished"></translation>
+        <translation>Item</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="65"/>
         <source>Kuvaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="79"/>
         <source>Tuotekoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>Product code</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="322"/>
         <source>Yhteishinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Total price</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="188"/>
         <source>Yksikköhinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Unit price</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="135"/>
         <source>Määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Quantity</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="141"/>
         <source>Toimitettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivered</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="148"/>
         <source>Jälkitoimitetaan</source>
-        <translation type="unfinished"></translation>
+        <translation>To be delivered later</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="155"/>
         <source>Laskutetaan</source>
-        <translation type="unfinished"></translation>
+        <translation>To be billed</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="162"/>
         <source>Yksikkö</source>
-        <translation type="unfinished"></translation>
+        <translation>Unit</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="227"/>
         <source>Tiliöinti</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="233"/>
         <source>Kirjanpitotili</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting account</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="243"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="253"/>
         <source>Merkkaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Tags</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="214"/>
         <source>Arvonlisävero</source>
-        <translation type="unfinished"></translation>
+        <translation>Value Added Tax</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="279"/>
         <source> %</source>
-        <translation type="unfinished"></translation>
+        <translation> %</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/laskurividialogi.ui" line="20"/>
         <source>Lisätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional information</translation>
     </message>
 </context>
 <context>
@@ -5716,77 +5769,77 @@ osoite</source>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="151"/>
         <source>Suodata otsikolla</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by title</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="153"/>
         <source>Suodata huoneistotunnuksella</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by apartment ID</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="145"/>
         <source>Suodata asiakkaan nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by customer name</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="147"/>
         <source>Suodata toimittajan nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by supplier name</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="149"/>
         <source>Suodata nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by name</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="155"/>
         <source>Suodata tuotteen nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by product name</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="164"/>
         <source>&amp;Myynnit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Sales</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="165"/>
         <source>&amp;Ostot</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Purchases</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="166"/>
         <source>&amp;Rekisteri</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Registry</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="167"/>
         <source>&amp;Asiakkaat</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Customers</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="168"/>
         <source>&amp;Toimittajat</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Suppliers</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="169"/>
         <source>T&amp;uotteet</source>
-        <translation type="unfinished"></translation>
+        <translation>P&amp;roducts</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="170"/>
         <source>&amp;Vakioviitteet</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Standard references</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="171"/>
         <source>&amp;Huoneistot</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Apartments</translation>
     </message>
     <message>
         <location filename="../laskutus/laskusivu.cpp" line="174"/>
         <source>Etsi asiakkaan nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Search by customer name</translation>
     </message>
 </context>
 <context>
@@ -5794,47 +5847,47 @@ osoite</source>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="40"/>
         <source>Numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Number</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="41"/>
         <source>Laskun pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice date</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="42"/>
         <source>Eräpvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Due date</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="43"/>
         <source>Summa</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="44"/>
         <source>Lähetystapa</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivery method</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="45"/>
         <source>Maksamatta</source>
-        <translation type="unfinished"></translation>
+        <translation>Unpaid</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="48"/>
         <source>Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Supplier</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="49"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../model/laskutaulumodel.cpp" line="51"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
 </context>
 <context>
@@ -5842,17 +5895,17 @@ osoite</source>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstimaaritys.cpp" line="16"/>
         <source>suomi</source>
-        <translation type="unfinished"></translation>
+        <translation>Finnish</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstimaaritys.cpp" line="17"/>
         <source>ruotsi</source>
-        <translation type="unfinished"></translation>
+        <translation>Swedish</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstimaaritys.cpp" line="18"/>
         <source>englanti</source>
-        <translation type="unfinished"></translation>
+        <translation>English</translation>
     </message>
 </context>
 <context>
@@ -5860,12 +5913,12 @@ osoite</source>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmaaritys.ui" line="40"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
 </context>
 <context>
@@ -5873,42 +5926,42 @@ osoite</source>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="9"/>
         <source>Saateviesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Cover message</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="9"/>
         <source>Kun lasku lähetetään sähköpostilla, sähköpostiviestin otsikko ja sisältö</source>
-        <translation type="unfinished"></translation>
+        <translation>When the invoice is sent by email, the email subject and content</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="10"/>
         <source>Laskun lisätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional invoice information</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="10"/>
         <source>Jokaiselle laskulle oletuksena lisättävät lisätiedot laskun alussa</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional information added by default to the beginning of each invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="11"/>
         <source>Kun maksumuistutus lähetetään sähköpostilla, sähköpostiviestin otsikko ja sisältö</source>
-        <translation type="unfinished"></translation>
+        <translation>When a payment reminder is sent by email, the email subject and content</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="12"/>
         <source>Maksumuistutuksen lisätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional payment reminder information</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="12"/>
         <source>Maksumuistutuksille oletuksena lisättävät lisätiedot laskun alussa</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional information added by default to the beginning of each payment reminder</translation>
     </message>
     <message>
         <location filename="../maaritys/laskutekstit/laskutekstitmodel.cpp" line="11"/>
         <source>Maksumuistutusviesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment reminder message</translation>
     </message>
 </context>
 <context>
@@ -5916,138 +5969,138 @@ osoite</source>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="25"/>
         <source>Laskutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="32"/>
         <source>Oletusvalinnat uusille laskuille</source>
-        <translation type="unfinished"></translation>
+        <translation>Default options for new invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="40"/>
         <source>Saatavatili</source>
-        <translation type="unfinished"></translation>
+        <translation>Receivables account</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="57"/>
         <source>Käteistili</source>
-        <translation type="unfinished"></translation>
+        <translation>Cash account</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="74"/>
         <source>Maksumuistustili</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment reminder account</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="91"/>
         <source>Viivästyskorkotili</source>
-        <translation type="unfinished"></translation>
+        <translation>Late payment interest account</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="108"/>
         <source>Ensimmäisen laskun numero</source>
-        <translation type="unfinished"></translation>
+        <translation>First invoice number</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="134"/>
         <source>Korttimaksutili</source>
-        <translation type="unfinished"></translation>
+        <translation>Card payment account</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="155"/>
         <source>Maksuaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment term</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="165"/>
         <location filename="../maaritys/laskumaaritys.ui" line="182"/>
         <source> vrk</source>
-        <translation type="unfinished"></translation>
+        <translation> days</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="175"/>
         <source>Huomautusaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Complaint period</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="192"/>
         <source>Viivästyskoron viitekorko</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference rate for late payment interest</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="199"/>
         <source> %</source>
-        <translation type="unfinished"></translation>
+        <translation> %</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="212"/>
         <source>Laskurivit</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice lines</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="229"/>
         <source>Desimaaleja yksikköhinnassa</source>
-        <translation type="unfinished"></translation>
+        <translation>Decimals in unit price</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="257"/>
         <source>Tulosta laskuille</source>
-        <translation type="unfinished"></translation>
+        <translation>Print on invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="265"/>
         <source>Tilinumerot</source>
-        <translation type="unfinished"></translation>
+        <translation>Account numbers</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="281"/>
         <source>Lisää IBAN ensin pankkitilin tietoihin kohdassa Tililuettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Add IBAN first to the bank account details in the Account List section</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="294"/>
         <source>Tilisiirto</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank transfer</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="308"/>
         <source>RF-viitteet</source>
-        <translation type="unfinished"></translation>
+        <translation>RF references</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="322"/>
         <source>Tuotekoodit</source>
-        <translation type="unfinished"></translation>
+        <translation>Product codes</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="336"/>
         <source>Tulostuspäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Print date</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="354"/>
         <source>Pankkiviivakoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank barcode</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="368"/>
         <source>QR-koodi</source>
-        <translation type="unfinished"></translation>
+        <translation>QR code</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="382"/>
         <source>Virtuaaliviivakoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>Virtual barcode</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="420"/>
         <source>Etäisyys yläreunaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Distance from top edge</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="427"/>
@@ -6055,22 +6108,22 @@ osoite</source>
         <location filename="../maaritys/laskumaaritys.ui" line="494"/>
         <location filename="../maaritys/laskumaaritys.ui" line="520"/>
         <source> mm</source>
-        <translation type="unfinished"></translation>
+        <translation> mm</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="453"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Etäisyys&lt;br/&gt;vasemmalle&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance&lt;br/&gt;to the left&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="487"/>
         <source>Ikkunan leveys</source>
-        <translation type="unfinished"></translation>
+        <translation>Window width</translation>
     </message>
     <message>
         <location filename="../maaritys/laskumaaritys.ui" line="513"/>
         <source>Ikkunan korkeus</source>
-        <translation type="unfinished"></translation>
+        <translation>Window height</translation>
     </message>
 </context>
 <context>
@@ -6078,162 +6131,162 @@ osoite</source>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="28"/>
         <source> - </source>
-        <translation type="unfinished"></translation>
+        <translation> - </translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="38"/>
         <source>Etsi numerolla</source>
-        <translation type="unfinished"></translation>
+        <translation>Search by number</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="82"/>
         <source>Näytä</source>
-        <translation type="unfinished"></translation>
+        <translation>Show</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="96"/>
         <source>Kopioi</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="110"/>
         <source>Lähetä</source>
-        <translation type="unfinished"></translation>
+        <translation>Send</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="137"/>
         <source>Hyvityslasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="151"/>
         <source>Maksumuistutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment reminder</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="175"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="199"/>
         <source>Uusi lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>New invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="210"/>
         <source>Ryhmälasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Group invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="221"/>
         <source>Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.ui" line="232"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="52"/>
         <source>&amp;Kirjanpidossa</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;In accounting</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="53"/>
         <source>&amp;Avoimet</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Open</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="54"/>
         <source>&amp;Erääntyneet</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Overdue</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="110"/>
         <source>Luonnokset</source>
-        <translation type="unfinished"></translation>
+        <translation>Drafts</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="111"/>
         <source>Lähetettävät</source>
-        <translation type="unfinished"></translation>
+        <translation>To be sent</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="112"/>
         <source>Kirjanpidossa</source>
-        <translation type="unfinished"></translation>
+        <translation>In accounting</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="119"/>
         <source>Kaikki</source>
-        <translation type="unfinished"></translation>
+        <translation>All</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="248"/>
         <source>Laskua ei voi luoda</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice cannot be created</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="248"/>
         <source>Kirjanpidossa ei ole avoinna olevaa tilikautta</source>
-        <translation type="unfinished"></translation>
+        <translation>There is no open accounting period in the bookkeeping</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="310"/>
         <source>Maksuperusteinen arvonlisävero</source>
-        <translation type="unfinished"></translation>
+        <translation>Cash-basis VAT</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="311"/>
         <source>Kitsaalla ei voi laatia maksumuistutuksia, kun maksuperusteinen arvonlisävero on käytössä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas cannot create payment reminders when cash-based VAT accounting is in use.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="335"/>
         <source>Laskun poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="336"/>
         <source>Haluatko todella poistaa laskun%1%2?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to delete the invoice%1%2?</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="337"/>
         <source> viitenumerolla %1</source>
-        <translation type="unfinished"></translation>
+        <translation> with reference number %1</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="338"/>
         <source> asiakkaalle %1</source>
-        <translation type="unfinished"></translation>
+        <translation> for customer %1</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="345"/>
         <source>Laskujen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete invoices</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="346"/>
         <source>Haluatko todellakin poistaa %1 laskua?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to delete %1 invoices?</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="375"/>
         <source>Myyntilaskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Sales invoices</translation>
     </message>
     <message>
         <location filename="../laskutus/laskulistawidget.cpp" line="377"/>
         <source>Ostolaskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Purchase invoices</translation>
     </message>
 </context>
 <context>
@@ -6241,52 +6294,52 @@ osoite</source>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="14"/>
         <source>Lasku maksettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice paid</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="27"/>
         <source>Etsi viitenumerolla tai asiakkaan nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Search by reference number or customer name</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="39"/>
         <source>&amp;Euroa</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Euros</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="55"/>
         <source> €</source>
-        <translation type="unfinished"></translation>
+        <translation> €</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="65"/>
         <source>Raha&amp;tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Money &amp;account</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="78"/>
         <source>Maksu&amp;päivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment &amp;date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="98"/>
         <source>&amp;Näytä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Show</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="105"/>
         <source>F9</source>
-        <translation type="unfinished"></translation>
+        <translation>F9</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="128"/>
         <source>&amp;Kirjaa</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Record</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunmaksudialogi.ui" line="139"/>
         <source>Sulje</source>
-        <translation type="unfinished"></translation>
+        <translation>Close</translation>
     </message>
 </context>
 <context>
@@ -6294,80 +6347,81 @@ osoite</source>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="98"/>
         <source>Lasku toimitettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice delivered</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="100"/>
         <source>%1 laskua toimitettu</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 invoices delivered</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="106"/>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="116"/>
         <source>Laskujen toimittaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to deliver invoices</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="107"/>
         <source>%1 laskua toimitettu
 %2 laskun toimittaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 invoices delivered
+%2 invoices failed to deliver</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="111"/>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="117"/>
         <source>Toimittamatta jääneet laskut löytyvät Lähetettävät-välilehdeltä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Undelivered invoices can be found in the To Be Sent tab.</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="150"/>
         <source>Tositteen lataus epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to load the document</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="161"/>
         <source>Ei ole myyntilasku #%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Not a sales invoice #%1</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="165"/>
         <source>Lasku on poistettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice has been deleted</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="169"/>
         <source>Lukitulla tilikaudella</source>
-        <translation type="unfinished"></translation>
+        <translation>In a locked accounting period</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="175"/>
         <source>Tallennusvirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Save error</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="207"/>
         <source>Tulostaminen peruttiin</source>
-        <translation type="unfinished"></translation>
+        <translation>Printing was cancelled</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.cpp" line="241"/>
         <source>Tositteen päivittäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to update the document</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.ui" line="46"/>
         <source>Toimitetaan laskuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivering invoices</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/laskuntoimittaja.ui" line="59"/>
         <source>%v / %m</source>
-        <translation type="unfinished"></translation>
+        <translation>%v / %m</translation>
     </message>
 </context>
 <context>
@@ -6375,7 +6429,7 @@ osoite</source>
     <message>
         <location filename="../laskutus/tulostus/laskuntulostaja.cpp" line="134"/>
         <source>Lasku %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Bill %1</translation>
     </message>
 </context>
 <context>
@@ -6383,23 +6437,24 @@ osoite</source>
     <message>
         <location filename="../laskutus/laskunuusinta.cpp" line="65"/>
         <source>Laskuja ei voitu uusia</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoices could not be renewed</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunuusinta.cpp" line="66"/>
         <source>Toistuvia laskuja ei voitu uusia, koska nykyiselle päivälle ei ole avointa tilikautta.
 Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</source>
-        <translation type="unfinished"></translation>
+        <translation>Recurring invoices could not be renewed because there is no open accounting period for the current date.
+Open an accounting period and restart the program to renew the invoices.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunuusinta.cpp" line="86"/>
         <source>Toistuvat laskut luotu Lähtevät-välilehdelle.</source>
-        <translation type="unfinished"></translation>
+        <translation>Recurring invoices created in the Outgoing tab.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskunuusinta.cpp" line="76"/>
         <source>Luodaan toistuvia laskuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating recurring invoices</translation>
     </message>
 </context>
 <context>
@@ -6407,109 +6462,109 @@ Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</so
     <message>
         <location filename="../raportti/laskuraportti.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="20"/>
         <source>Laskutyyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice type</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="26"/>
         <source>Myyntilaskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Sales invoices</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="36"/>
         <source>Ostolaskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Purchase invoices</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="46"/>
         <source>Päivämäärärajaus  </source>
-        <translation type="unfinished"></translation>
+        <translation>Date range  </translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="52"/>
         <location filename="../raportti/laskuraportti.ui" line="177"/>
         <source>Laskun päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice date</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="59"/>
         <location filename="../raportti/laskuraportti.ui" line="187"/>
         <source>Eräpäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Due date</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="66"/>
         <source>Tulosta kaikki</source>
-        <translation type="unfinished"></translation>
+        <translation>Print all</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="76"/>
         <source>Alkaen</source>
-        <translation type="unfinished"></translation>
+        <translation>Starting from</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="93"/>
         <source>Päättyen</source>
-        <translation type="unfinished"></translation>
+        <translation>Ending on</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="115"/>
         <source>Saldopäivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance date</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="144"/>
         <source>Vain avoimet</source>
-        <translation type="unfinished"></translation>
+        <translation>Only open</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="154"/>
         <source>Lajittelu</source>
-        <translation type="unfinished"></translation>
+        <translation>Sorting</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="160"/>
         <source>Laskun numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice number</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="167"/>
         <source>Viitenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference number</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="194"/>
         <source>Laskun summa</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice amount</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="201"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="211"/>
         <source>Näytä viitenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Show reference number</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="218"/>
         <source>Vain Kitsaalla laaditut laskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Only invoices created with Kitsas</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="225"/>
         <source>Tulosta yhteissumma</source>
-        <translation type="unfinished"></translation>
+        <translation>Print total sum</translation>
     </message>
     <message>
         <location filename="../raportti/laskuraportti.ui" line="237"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
 </context>
 <context>
@@ -6517,17 +6572,17 @@ Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</so
     <message>
         <location filename="../laskutus/ryhmalasku/laskutettavatmodel.cpp" line="33"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/laskutettavatmodel.cpp" line="34"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/laskutettavatmodel.cpp" line="35"/>
         <source>Lähetystapa</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivery method</translation>
     </message>
 </context>
 <context>
@@ -6535,23 +6590,23 @@ Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</so
     <message>
         <location filename="../tilaus/laskutustietodialog.cpp" line="30"/>
         <source>Laskutustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing information</translation>
     </message>
     <message>
         <location filename="../tilaus/laskutustietodialog.cpp" line="56"/>
         <location filename="../tilaus/laskutustietodialog.cpp" line="66"/>
         <source>Puutteelliset laskutustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Incomplete billing information</translation>
     </message>
     <message>
         <location filename="../tilaus/laskutustietodialog.cpp" line="56"/>
         <source>Sähköpostiosoite on virheellinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address is invalid</translation>
     </message>
     <message>
         <location filename="../tilaus/laskutustietodialog.cpp" line="66"/>
         <source>Nimi, osoite tai verkkolaskutiedot ovat puutteellisia.</source>
-        <translation type="unfinished"></translation>
+        <translation>Name, address or e-invoicing details are incomplete.</translation>
     </message>
 </context>
 <context>
@@ -6559,12 +6614,12 @@ Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</so
     <message>
         <location filename="../liite/liite.cpp" line="183"/>
         <source>Liitteen tallentaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save attachment</translation>
     </message>
     <message>
         <location filename="../liite/liite.cpp" line="184"/>
         <source>Liitteen tallentamisessa tapahtui virhe %1 : %2</source>
-        <translation type="unfinished"></translation>
+        <translation>An error occurred while saving the attachment %1 : %2</translation>
     </message>
 </context>
 <context>
@@ -6572,69 +6627,69 @@ Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</so
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="26"/>
         <source>Liitteiden käsittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Attachment Handling</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="35"/>
         <source>Tekstintunnistus kuvatiedostoista</source>
-        <translation type="unfinished"></translation>
+        <translation>Text recognition from image files</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="49"/>
         <source>Ominaisuus käytössä vain tilaajille</source>
-        <translation type="unfinished"></translation>
+        <translation>Feature available only for subscribers</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="71"/>
         <source>Tiedostojen koon pienentäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Reducing file size</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="77"/>
         <source>Muuta mustavalkoiseksi</source>
-        <translation type="unfinished"></translation>
+        <translation>Convert to black and white</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="88"/>
         <source>Kuvan koko</source>
-        <translation type="unfinished"></translation>
+        <translation>Image size</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="97"/>
         <location filename="../maaritys/liitemaaritys.ui" line="199"/>
         <source>Pieni</source>
-        <translation type="unfinished"></translation>
+        <translation>Small</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="129"/>
         <location filename="../maaritys/liitemaaritys.ui" line="231"/>
         <source>Suuri</source>
-        <translation type="unfinished"></translation>
+        <translation>Large</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="138"/>
         <source>Kuvan laatu</source>
-        <translation type="unfinished"></translation>
+        <translation>Image quality</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="147"/>
         <source>Matala</source>
-        <translation type="unfinished"></translation>
+        <translation>Low</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="179"/>
         <source>Korkea</source>
-        <translation type="unfinished"></translation>
+        <translation>High</translation>
     </message>
     <message>
         <location filename="../maaritys/liitemaaritys.ui" line="191"/>
         <source>Liitteiden katselu</source>
-        <translation type="unfinished"></translation>
+        <translation>View attachments</translation>
     </message>
 </context>
 <context>
@@ -6642,22 +6697,22 @@ Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</so
     <message>
         <location filename="../raportti/liitepoimija.cpp" line="212"/>
         <source>Tositekooste</source>
-        <translation type="unfinished"></translation>
+        <translation>Document summary</translation>
     </message>
     <message>
         <location filename="../raportti/liitepoimija.cpp" line="212"/>
         <source>Tekemilläsi valinnoilla muodostuu tyhjä tositekooste</source>
-        <translation type="unfinished"></translation>
+        <translation>With your selections, an empty document summary is formed</translation>
     </message>
     <message>
         <location filename="../raportti/liitepoimija.cpp" line="219"/>
         <source>Tiedoston näyttäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to display the file</translation>
     </message>
     <message>
         <location filename="../raportti/liitepoimija.cpp" line="220"/>
         <source>Kitsas ei saanut käynnistettyä ulkoista ohjelmaa tiedoston %1 näyttämiseksi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas failed to launch an external program to display file %1.</translation>
     </message>
 </context>
 <context>
@@ -6665,41 +6720,44 @@ Avaa tilikausi ja käynnistä ohjelma uudelleen, jotta laskut voidaan uusia.</so
     <message>
         <location filename="../liite/liitteetmodel.cpp" line="181"/>
         <source>Liitetiedoston tyyppiä ei tueta</source>
-        <translation type="unfinished"></translation>
+        <translation>Attachment file type not supported</translation>
     </message>
     <message>
         <location filename="../liite/liitteetmodel.cpp" line="182"/>
         <source>Tätä liitetiedostoa ei voi välttämättä näyttää Kitsaalla eikä sisällyttää arkistoon.
 Haluatko silti lisätä tämän tiedoston?</source>
-        <translation type="unfinished"></translation>
+        <translation>This attachment may not be displayable in Kitsas or included in the archive.
+Do you still want to add this file?</translation>
     </message>
     <message>
         <location filename="../liite/liitteetmodel.cpp" line="226"/>
         <source>Tiedostovirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>File error</translation>
     </message>
     <message>
         <location filename="../liite/liitteetmodel.cpp" line="227"/>
         <source>Tiedoston %1 avaaminen epäonnistui 
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to open file %1 
+%2</translation>
     </message>
     <message>
         <location filename="../liite/liitteetmodel.cpp" line="385"/>
         <location filename="../liite/liitteetmodel.cpp" line="390"/>
         <source>liite.jpg</source>
-        <translation type="unfinished"></translation>
+        <translation>attachment.jpg</translation>
     </message>
     <message>
         <location filename="../liite/liitteetmodel.cpp" line="549"/>
         <source>Liitetiedosto liian suuri</source>
-        <translation type="unfinished"></translation>
+        <translation>Attachment file too large</translation>
     </message>
     <message>
         <location filename="../liite/liitteetmodel.cpp" line="550"/>
         <source>Liitetiedostoa ei voi lisätä kirjanpitoon, koska liite on kooltaan liian suuri.
 Voit lisätä enintään 10 megatavun kokoisen liitteen.</source>
-        <translation type="unfinished"></translation>
+        <translation>The attachment cannot be added to the accounting because it is too large.
+You can add an attachment up to 10 megabytes in size.</translation>
     </message>
 </context>
 <context>
@@ -6707,12 +6765,12 @@ Voit lisätä enintään 10 megatavun kokoisen liitteen.</source>
     <message>
         <location filename="../lisaikkuna.cpp" line="57"/>
         <source>%1 - Kirjaus</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - Entry</translation>
     </message>
     <message>
         <location filename="../lisaikkuna.cpp" line="73"/>
         <source>%1 - Selaus</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - Browse</translation>
     </message>
 </context>
 <context>
@@ -6720,38 +6778,38 @@ Voit lisätä enintään 10 megatavun kokoisen liitteen.</source>
     <message>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="56"/>
         <source> Vain testikäyttäjille </source>
-        <translation type="unfinished"></translation>
+        <translation> Only for test users </translation>
     </message>
     <message>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="105"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="110"/>
         <source>Tapahtumat</source>
-        <translation type="unfinished"></translation>
+        <translation>Events</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="114"/>
         <source>Poista käytöstä</source>
-        <translation type="unfinished"></translation>
+        <translation>Disable</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="118"/>
         <source>Ota käyttöön</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="128"/>
         <source>Poistatko käytöstä lisäosan %1?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to disable the add-on %1?</translation>
     </message>
     <message>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="216"/>
         <location filename="../maaritys/extra/lisapalveluwidget.cpp" line="226"/>
         <source>Jatka verkkoselaimella osoitteeseen &lt;a href=%1&gt;%1&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Continue to the web browser at &lt;a href=%1&gt;%1&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
@@ -6759,47 +6817,47 @@ Voit lisätä enintään 10 megatavun kokoisen liitteen.</source>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="14"/>
         <source>Lisää raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>Add report</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="26"/>
         <source>Raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>Report</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="39"/>
         <source>Tulostettava otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Printable header</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="54"/>
         <source>Erittely tileittäin</source>
-        <translation type="unfinished"></translation>
+        <translation>Breakdown by accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="61"/>
         <source>Tuloslaskelman valinnat</source>
-        <translation type="unfinished"></translation>
+        <translation>Income statement options</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="67"/>
         <source>Kokonaislaskelma</source>
-        <translation type="unfinished"></translation>
+        <translation>Total calculation</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="77"/>
         <source>Kustannuspaikat</source>
-        <translation type="unfinished"></translation>
+        <translation>Cost centers</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="84"/>
         <source>Projektit</source>
-        <translation type="unfinished"></translation>
+        <translation>Projects</translation>
     </message>
     <message>
         <location filename="../maaritys/lisaaraporttidialogi.ui" line="91"/>
         <source>Budjettivertailu</source>
-        <translation type="unfinished"></translation>
+        <translation>Budget comparison</translation>
     </message>
 </context>
 <context>
@@ -6807,12 +6865,12 @@ Voit lisätä enintään 10 megatavun kokoisen liitteen.</source>
     <message>
         <location filename="../lisaosat/lisaosalokimodel.cpp" line="18"/>
         <source>Aika</source>
-        <translation type="unfinished"></translation>
+        <translation>Time</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosalokimodel.cpp" line="19"/>
         <source>Tapahtuma</source>
-        <translation type="unfinished"></translation>
+        <translation>Event</translation>
     </message>
 </context>
 <context>
@@ -6820,47 +6878,47 @@ Voit lisätä enintään 10 megatavun kokoisen liitteen.</source>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="81"/>
         <source>Zoom</source>
-        <translation type="unfinished"></translation>
+        <translation>Suurennus</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="92"/>
         <source>Ota käyttöön</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="93"/>
         <source>Poista käytöstä</source>
-        <translation type="unfinished"></translation>
+        <translation>Disable</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="95"/>
         <source>Alkuun</source>
-        <translation type="unfinished"></translation>
+        <translation>Back to start</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="98"/>
         <source>Näytä tapahtumat</source>
-        <translation type="unfinished"></translation>
+        <translation>Show events</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="99"/>
         <source>Ota käyttöön yksityinen lisäosa</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable private plugin</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="205"/>
         <source>Lisäosan käyttöönottaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to enable plugin</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="205"/>
         <source>Lisäosan tunniste on virheellinen tai käyttöönotossa tapahtui virhe.</source>
-        <translation type="unfinished"></translation>
+        <translation>The plugin identifier is invalid or an error occurred during activation.</translation>
     </message>
     <message>
         <location filename="../lisaosat/lisaosasivu.cpp" line="283"/>
         <source>%1 ladattu</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 downloaded</translation>
     </message>
 </context>
 <context>
@@ -6868,59 +6926,61 @@ Voit lisätä enintään 10 megatavun kokoisen liitteen.</source>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="186"/>
         <source>Virheellinen salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="194"/>
         <source>Virhe kirjautumisessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Login error</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="195"/>
         <source>Palvelin ilmoitti virheen %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Server reported error %1</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="166"/>
         <source>Palvelin ei juuri nyt ole käytettävissä. Yritä myöhemmin uudelleen.</source>
-        <translation type="unfinished"></translation>
+        <translation>The server is currently unavailable. Please try again later.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="59"/>
         <source>Kirjoita ensin sähköpostiosoitteesi</source>
-        <translation type="unfinished"></translation>
+        <translation>Please enter your email address first</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="172"/>
         <source>Palvelu on tilapäisesti poissa käytöstä.</source>
-        <translation type="unfinished"></translation>
+        <translation>The service is temporarily unavailable.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="174"/>
         <source>Palvelinyhteydessä on virhe (%1: %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>There is an error in the server connection (%1: %2)</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="259"/>
         <source>Salasanan vaihtaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Password change failed</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="260"/>
         <source>Salasanan vaihtopyynnön lähettäminen palvelimelle epäonnistui tietoliikennevirheen %1 takia.
 
 Yritä myöhemmin uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Sending the password change request to the server failed due to communication error %1.
+
+Please try again later</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="265"/>
         <source>Salasanan palauttaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Password recovery</translation>
     </message>
     <message>
         <location filename="../aloitussivu/loginservice.cpp" line="266"/>
         <source>Sähköpostiisi on lähetetty linkki, jonka avulla voit vaihtaa salasanan.</source>
-        <translation type="unfinished"></translation>
+        <translation>A link to change your password has been sent to your email.</translation>
     </message>
 </context>
 <context>
@@ -6928,22 +6988,22 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../arkisto/lukitsetilikausi.ui" line="14"/>
         <source>Tilinpäätöksen laatiminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Preparing financial statements</translation>
     </message>
     <message>
         <location filename="../arkisto/lukitsetilikausi.ui" line="32"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Esikatsele tilikauden raportit, etenkin tuloslaskelma ja tase varmistaaksesi, että kaikki kirjanpitoaineisto on valmiina.&lt;/p&gt;&lt;p&gt;Kun olet varma, että kirjanpitoaineisto on valmis, jatka tilinpäätöksen laatimista &lt;span style=&quot; font-weight:600;&quot;&gt;lukitsemalla tilikausi&lt;/span&gt;. Kun tilikausi on lukittu, ei tilikauden tapahtumia voi enää muokata.&lt;/p&gt;&lt;p&gt;Samalla tilikauden kirjanpidosta muodostetaan sähköinen arkisto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preview the financial reports, especially the income statement and balance sheet, to ensure that all accounting materials are ready.&lt;/p&gt;&lt;p&gt;When you are sure that the accounting materials are complete, continue preparing the financial statements by &lt;span style=&quot; font-weight:600;&quot;&gt;locking the accounting period&lt;/span&gt;. Once the accounting period is locked, you can no longer modify the transactions for that period.&lt;/p&gt;&lt;p&gt;At the same time, an electronic archive of the accounting period&apos;s accounting will be created.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../arkisto/lukitsetilikausi.ui" line="57"/>
         <source>Peruuta</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../arkisto/lukitsetilikausi.ui" line="81"/>
         <source>Lukitse tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Lock accounting period</translation>
     </message>
 </context>
 <context>
@@ -6951,56 +7011,60 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="14"/>
         <source>Uusi käyttäjätunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>New user account</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="27"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Luomalla käyttäjätunnuksen aloitat Kitsaan pilvipalveluiden maksuttoman kokeilujakson. Saat käyttöösi Kitsaan kaikki ominaisuudet ja voit tallettaa yhden kirjanpidon Kitsaan suomalaiseen pilveen. Toki voit edelleet tallentaa kirjanpitoja myös omalle tietokoneellesi.&lt;/p&gt;&lt;p&gt;Ellet kokeilujakson aikana tee maksullista tilausta, jatkat kokeilujakson jälkeen ilmaiskäyttäjänä. Tällöin myös kokeilujakson aikana pilveen mahdollisesti luomasi kirjanpito poistetaan. &lt;/p&gt;&lt;p&gt;Ennen aloittamista tutustu Kitsaan käyttöehtoihin osoitteessa &lt;a href=&quot;https://kitsas.fi/ehdot&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;kitsas.fi/ehdot&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By creating a user account, you start a free trial period for Kitsas cloud services. You&apos;ll get access to all Kitsas features and can store one accounting record in the Finnish Kitsas cloud. Of course, you can still save accounting records on your own computer as well.&lt;/p&gt;&lt;p&gt;If you don&apos;t make a paid subscription during the trial period, you&apos;ll continue as a free user after the trial. In this case, any accounting records you may have created in the cloud during the trial period will also be deleted.&lt;/p&gt;&lt;p&gt;Before starting, please review the Kitsas terms of use at &lt;a href=&quot;https://kitsas.fi/ehdot&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;kitsas.fi/ehdot&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="53"/>
         <source>Hyväksyn pilvipalvelun käyttöehdot</source>
-        <translation type="unfinished"></translation>
+        <translation>I accept the cloud service terms of use</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="84"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Olet luomassa käyttäjätunnusta Kitsaan pilveen.&lt;/p&gt;&lt;p&gt;Aloita antamalla sähköpostiosoitteesi. Hetken kuluttua saat sähköpostiisi linkin, jonka kautta pääset viimeistelemään tunnuksesi sekä asettamaan salasanan.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You are creating a user account for Kitsas cloud.&lt;/p&gt;&lt;p&gt;Start by providing your email address. Shortly, you will receive an email with a link that allows you to complete your account creation and set a password.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="96"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="109"/>
         <source>Sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="151"/>
         <source>Otan yhteyttä Kitsaan palvelimelle...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecting to Kitsas server...</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.ui" line="165"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.cpp" line="80"/>
         <source>Rekisteröinnin lähettäminen palvelimelle epäonnistui tietoliikennevirheen %1 takia.
 
 Yritä myöhemmin uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Registration submission to the server failed due to communication error %1.
+
+Please try again later</translation>
     </message>
     <message>
         <location filename="../aloitussivu/luotunnusdialogi.cpp" line="84"/>
         <source>Sinulle on lähetetty osoitteeseen %1 sähköpostiviesti, jossa olevalla linkillä pääset viimeistelemään käyttäjätunnuksen luomisen ja asettamaan itsellesi salasanan.
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation>An email has been sent to %1 with a link that allows you to complete the user account creation and set a password for yourself.
+
+</translation>
     </message>
 </context>
 <context>
@@ -7008,151 +7072,151 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="70"/>
         <source>Perusvalinnat</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic settings</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="71"/>
         <source>Yhteystiedot ja toiminimet</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact information and trade names</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="74"/>
         <source>Tililuettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="75"/>
         <source>Kohdennukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocations</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="76"/>
         <source>Tilinavaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening entry</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="77"/>
         <source>Laskutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="78"/>
         <source>Laskujen tekstit</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice texts</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="79"/>
         <source>Laskujen bannerit</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice banners</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="80"/>
         <source>Oletustilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Default accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="81"/>
         <source>Maksutavat</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment methods</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="82"/>
         <source>Tositesarjat</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher series</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="87"/>
         <source>Verot</source>
-        <translation type="unfinished"></translation>
+        <translation>Taxes</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="69"/>
         <source>Käyttöliittymä</source>
-        <translation type="unfinished"></translation>
+        <translation>User interface</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="68"/>
         <source>Minä</source>
-        <translation type="unfinished"></translation>
+        <translation>Me</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="72"/>
         <source>Liitteiden käsittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Attachment Handling</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="73"/>
         <source>Käyttöoikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>User Rights</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="83"/>
         <source>Sähköpostin lähetys</source>
-        <translation type="unfinished"></translation>
+        <translation>Email Sending</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="84"/>
         <source>Laskujen kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice circulation</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="85"/>
         <source>Verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="86"/>
         <source>Kirjattavien kansio</source>
-        <translation type="unfinished"></translation>
+        <translation>Folder for Items to be Recorded</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="88"/>
         <source>Palkkakirjaustilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Salary Posting Accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="89"/>
         <source>Raportit</source>
-        <translation type="unfinished"></translation>
+        <translation>Reports</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="90"/>
         <source>Tilinpäätöksen malli</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial Statement Template</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="91"/>
         <source>Tilikartan päivitys</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts update</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="92"/>
         <source>Lisäpalvelut</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional Services</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="105"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="106"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="140"/>
         <location filename="../maaritys/maarityssivu.cpp" line="172"/>
         <location filename="../maaritys/maarityssivu.cpp" line="204"/>
         <source>Kitsas</source>
-        <translation type="unfinished"></translation>
+        <translation>Narrow</translation>
     </message>
     <message>
         <location filename="../maaritys/maarityssivu.cpp" line="140"/>
         <location filename="../maaritys/maarityssivu.cpp" line="172"/>
         <location filename="../maaritys/maarityssivu.cpp" line="204"/>
         <source>Asetuksia on muutettu. Poistutko sivulta tallentamatta tekemiäsi muutoksia?</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings have been changed. Do you want to leave the page without saving your changes?</translation>
     </message>
 </context>
 <context>
@@ -7160,12 +7224,12 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../laskutus/laskudlg/maksumuistusdialogi.cpp" line="58"/>
         <source>Maksumuistutus %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment Reminder %1</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/maksumuistusdialogi.cpp" line="59"/>
         <source>Maksumuistutuksen pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment Reminder Date</translation>
     </message>
 </context>
 <context>
@@ -7173,32 +7237,32 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../laskutus/uusimaksumuistutusdialogi.ui" line="14"/>
         <source>Muodosta maksumuistutukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Create payment reminders</translation>
     </message>
     <message>
         <location filename="../laskutus/uusimaksumuistutusdialogi.ui" line="22"/>
         <source>Lisää maksumuistutuksesta</source>
-        <translation type="unfinished"></translation>
+        <translation>Add from payment reminder</translation>
     </message>
     <message>
         <location filename="../laskutus/uusimaksumuistutusdialogi.ui" line="29"/>
         <source> €</source>
-        <translation type="unfinished"></translation>
+        <translation> €</translation>
     </message>
     <message>
         <location filename="../laskutus/uusimaksumuistutusdialogi.ui" line="39"/>
         <source>Lisää viivästyskorko</source>
-        <translation type="unfinished"></translation>
+        <translation>Add late payment interest</translation>
     </message>
     <message>
         <location filename="../laskutus/uusimaksumuistutusdialogi.ui" line="46"/>
         <source>Eräpäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Due date</translation>
     </message>
     <message>
         <location filename="../laskutus/uusimaksumuistutusdialogi.ui" line="58"/>
         <source>Muodostetut maksumuistutukset löydät Lähetettävät-välilehdeltä.</source>
-        <translation type="unfinished"></translation>
+        <translation>You can find the created payment reminders in the To Be Sent tab.</translation>
     </message>
 </context>
 <context>
@@ -7206,32 +7270,32 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../maaritys/maksuperusteinen.ui" line="14"/>
         <source>Maksuperusteinen arvonlisävero</source>
-        <translation type="unfinished"></translation>
+        <translation>Cash-basis VAT</translation>
     </message>
     <message>
         <location filename="../maaritys/maksuperusteinen.ui" line="32"/>
         <source>Ennen maksuperusteisen arvonlisäveron käyttöön ottamista lue huolellisesti maksuperusteisen arvonlisäveron ohjeet.</source>
-        <translation type="unfinished"></translation>
+        <translation>Before implementing cash-basis VAT, carefully read the instructions for cash-basis VAT.</translation>
     </message>
     <message>
         <location filename="../maaritys/maksuperusteinen.ui" line="59"/>
         <source>Maksuperusteinen arvonlisäverotus alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Cash-basis VAT taxation begins</translation>
     </message>
     <message>
         <location filename="../maaritys/maksuperusteinen.ui" line="73"/>
         <source>Suoriteperusteiseen arvonlisäveroon palataan</source>
-        <translation type="unfinished"></translation>
+        <translation>Return to accrual-basis VAT</translation>
     </message>
     <message>
         <location filename="../maaritys/maksuperusteinen.ui" line="104"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../maaritys/maksuperusteinen.ui" line="111"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
 </context>
 <context>
@@ -7239,22 +7303,22 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../model/maksutapamodel.cpp" line="33"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../model/maksutapamodel.cpp" line="35"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../model/maksutapamodel.cpp" line="37"/>
         <source>Uusi erä</source>
-        <translation type="unfinished"></translation>
+        <translation>New entry</translation>
     </message>
     <message>
         <location filename="../model/maksutapamodel.cpp" line="66"/>
         <source>Kaikki vastatilit</source>
-        <translation type="unfinished"></translation>
+        <translation>All contra accounts</translation>
     </message>
 </context>
 <context>
@@ -7262,32 +7326,32 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../maaritys/maksutapamuokkaus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkaus.ui" line="38"/>
         <source>Lisää </source>
-        <translation type="unfinished"></translation>
+        <translation>Add </translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkaus.ui" line="49"/>
         <source>Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkaus.ui" line="60"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkaus.ui" line="71"/>
         <source>Ylöspäin</source>
-        <translation type="unfinished"></translation>
+        <translation>Up</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkaus.ui" line="82"/>
         <source>Alaspäin</source>
-        <translation type="unfinished"></translation>
+        <translation>Down</translation>
     </message>
 </context>
 <context>
@@ -7295,27 +7359,27 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../maaritys/maksutapamuokkausdlg.ui" line="14"/>
         <source>Maksutapa</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment method</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkausdlg.ui" line="22"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkausdlg.ui" line="39"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkausdlg.ui" line="52"/>
         <source>Uusi tase-erä</source>
-        <translation type="unfinished"></translation>
+        <translation>New balance item</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapamuokkausdlg.ui" line="59"/>
         <source>Kuvake</source>
-        <translation type="unfinished"></translation>
+        <translation>Icon</translation>
     </message>
 </context>
 <context>
@@ -7323,42 +7387,42 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="26"/>
         <source>Maksutavat</source>
-        <translation type="unfinished"></translation>
+        <translation>Payment methods</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="41"/>
         <source>Tuloille</source>
-        <translation type="unfinished"></translation>
+        <translation>For income</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="55"/>
         <source>Menoille</source>
-        <translation type="unfinished"></translation>
+        <translation>For expenses</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="68"/>
         <source>Näytä laskun lisätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Show invoice details</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="74"/>
         <source>Laskuille</source>
-        <translation type="unfinished"></translation>
+        <translation>For invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="85"/>
         <source>Kaikille</source>
-        <translation type="unfinished"></translation>
+        <translation>For all</translation>
     </message>
     <message>
         <location filename="../maaritys/maksutapasivu.ui" line="96"/>
         <source>Ei koskaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Never</translation>
     </message>
 </context>
 <context>
@@ -7366,129 +7430,131 @@ Yritä myöhemmin uudelleen</source>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="14"/>
         <source>Verkkolaskutus</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoicing</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="28"/>
         <source>Avaimet ja laskutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Keys and billing</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="34"/>
         <source>Avaimet</source>
-        <translation type="unfinished"></translation>
+        <translation>Keys</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="42"/>
         <source>API-avain</source>
-        <translation type="unfinished"></translation>
+        <translation>API key</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="52"/>
         <source>Yrityksen UUID</source>
-        <translation type="unfinished"></translation>
+        <translation>Company UUID</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="67"/>
         <source>Laskutus</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="73"/>
         <source>Kitsas laskuttaa hinnastonsa mukaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas bills according to its price list</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="80"/>
         <source>Maventa laskuttaa suoraan oman hinnastonsa mukaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Maventa bills directly according to its own price list</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="90"/>
         <source>Nouda  saapuneet verkkolaskut automaattisesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatically retrieve received e-invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="119"/>
         <source>Sähköposti-ilmoitukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Email notifications</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="127"/>
         <source>Saapuneista laskuista osoitteeseen</source>
-        <translation type="unfinished"></translation>
+        <translation>For received invoices to address</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="137"/>
         <source>Lähetysvirheistä osoitteeseen</source>
-        <translation type="unfinished"></translation>
+        <translation>For sending errors to address</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="147"/>
         <source>Myös käyttäjän sähköpostiin</source>
-        <translation type="unfinished"></translation>
+        <translation>Also to user&apos;s email</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="174"/>
         <source>Paperilaskujen postitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Mailing of paper invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="180"/>
         <source>Tulostus- ja postituspalvelu käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Printing and mailing service in use</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="187"/>
         <source>Toimita postitettavaksi valitut laskut postituspalvelua käyttäen</source>
-        <translation type="unfinished"></translation>
+        <translation>Deliver selected invoices for mailing using the mailing service</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="194"/>
         <source>Kotimaan kirjeet</source>
-        <translation type="unfinished"></translation>
+        <translation>Domestic letters</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="200"/>
         <source>Priority</source>
-        <translation type="unfinished"></translation>
+        <translation>Priority</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="207"/>
         <source>Economy</source>
-        <translation type="unfinished"></translation>
+        <translation>Economy</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="217"/>
         <source>Värit</source>
-        <translation type="unfinished"></translation>
+        <translation>Colors</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="223"/>
         <source>Mustavalkoinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Black and white</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="230"/>
         <source>Värillinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Colored</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventa.ui" line="240"/>
         <source>Liitä oma laskunkuva </source>
-        <translation type="unfinished"></translation>
+        <translation>Attach your own invoice image </translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventadialog.cpp" line="214"/>
         <source>Maventa asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Maventa settings</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/maventadialog.cpp" line="214"/>
         <source>Maventan asetusten muuttaminen epäonnistui.
 
 Tarkasta kirjoittamasi avaimet.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to change Maventa settings.
+
+Check the keys you entered.</translation>
     </message>
 </context>
 <context>
@@ -7496,173 +7562,173 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="25"/>
         <source>Käyttäjätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>User Information</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="34"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="47"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="60"/>
         <source>Puhelinnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="75"/>
         <source>Tunnistautuminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Authentication</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="81"/>
         <location filename="../maaritys/minamaaritys.cpp" line="163"/>
         <source>Kaksivaiheinen tunnistautuminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Two-factor authentication</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="101"/>
         <source>Vaihda salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Change password</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="115"/>
         <source>Sähköposti-ilmoitukset kierrossa olevista laskuista</source>
-        <translation type="unfinished"></translation>
+        <translation>Email notifications for circulating invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="126"/>
         <source>Maanantaisin</source>
-        <translation type="unfinished"></translation>
+        <translation>On Mondays</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="133"/>
         <source>Lauantaisin</source>
-        <translation type="unfinished"></translation>
+        <translation>On Saturdays</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="140"/>
         <source>Tiistaisin</source>
-        <translation type="unfinished"></translation>
+        <translation>On Tuesdays</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="147"/>
         <source>Sunnuntaisin</source>
-        <translation type="unfinished"></translation>
+        <translation>On Sundays</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="154"/>
         <source>Keskiviikkoisin</source>
-        <translation type="unfinished"></translation>
+        <translation>On Wednesdays</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="161"/>
         <source>Torstaisin</source>
-        <translation type="unfinished"></translation>
+        <translation>On Thursdays</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="168"/>
         <source>Perjantaisin</source>
-        <translation type="unfinished"></translation>
+        <translation>On Fridays</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="193"/>
         <source>Näkymä</source>
-        <translation type="unfinished"></translation>
+        <translation>View</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="199"/>
         <source>Kitsaan tilaaja tai kokeilija</source>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas subscriber or trial user</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="210"/>
         <source>Tilitoimistokäyttäjä tai tilitoimiston asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting firm user or accounting firm client</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="224"/>
         <source>Tilaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Subscription</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="230"/>
         <source>Tilausinfo</source>
-        <translation type="unfinished"></translation>
+        <translation>Order information</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="252"/>
         <source>Tee tilaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Make an order</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.ui" line="263"/>
         <source>Laskutustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing information</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="42"/>
         <source>Käytössä %1 kirjanpitoa</source>
-        <translation type="unfinished"></translation>
+        <translation>Using %1 accounting(s)</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="43"/>
         <source>Tilaukseen sisältyy %1, jonka jälkeen lisäkirjanpidot maksavat %2 /kk</source>
-        <translation type="unfinished"></translation>
+        <translation>The subscription includes %1, after which additional accountings cost %2 /month</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="44"/>
         <source>yksi kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>one accounting</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="44"/>
         <source>%1 kirjanpitoa</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 accountings</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="47"/>
         <source>Tilaukseni</source>
-        <translation type="unfinished"></translation>
+        <translation>My subscription</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="49"/>
         <source>Kokeilujakso %1 saakka</source>
-        <translation type="unfinished"></translation>
+        <translation>Trial period until %1</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="51"/>
         <source>Ei voimassa olevaa tilausta</source>
-        <translation type="unfinished"></translation>
+        <translation>No active subscription</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="164"/>
         <source>Ota kaksivaiheinen tunnistautuminen käyttöön selaimeesi avautuvan QR-koodin avulla.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable two-factor authentication using the QR code that opens in your browser.</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="172"/>
         <source>Sähköpostiosoitteen vaihtaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Change email address</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="173"/>
         <source>Sähköpostiosoitteen vaihtaminen epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to change email address.</translation>
     </message>
     <message>
         <location filename="../maaritys/minamaaritys.cpp" line="174"/>
         <source>Tällä sähköpostiosoitteella on jo mahdollisesti Kitsaan käyttäjätunnus.</source>
-        <translation type="unfinished"></translation>
+        <translation>This email address may already have a Kitsas user account.</translation>
     </message>
 </context>
 <context>
@@ -7670,12 +7736,12 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../aloitussivu/muistiinpanot.ui" line="14"/>
         <source>Muistiinpanot</source>
-        <translation type="unfinished"></translation>
+        <translation>Notes</translation>
     </message>
     <message>
         <location filename="../aloitussivu/muistiinpanot.ui" line="42"/>
         <source>&amp;Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Save</translation>
     </message>
 </context>
 <context>
@@ -7683,69 +7749,69 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="43"/>
         <source>Sarake 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Column 1</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="64"/>
         <location filename="../raportti/muokattavaraportti.ui" line="210"/>
         <source>Päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>Ends</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="77"/>
         <source>Sarake 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Column 2</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="101"/>
         <location filename="../raportti/muokattavaraportti.ui" line="200"/>
         <source>Alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Starts</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="114"/>
         <source>Sarake 3</source>
-        <translation type="unfinished"></translation>
+        <translation>Column 3</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="133"/>
         <source>Sarake 4</source>
-        <translation type="unfinished"></translation>
+        <translation>Column 4</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="159"/>
         <source>Raportin muoto</source>
-        <translation type="unfinished"></translation>
+        <translation>Report format</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="182"/>
         <source>Kohdennuksella</source>
-        <translation type="unfinished"></translation>
+        <translation>With Allocation</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="239"/>
         <source>Ynteensä-sarake</source>
-        <translation type="unfinished"></translation>
+        <translation>Total column</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="250"/>
         <source>Huomioi jaksotukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Consider accruals</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="172"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../raportti/muokattavaraportti.ui" line="228"/>
         <source>Tulosta tilikohtaiset erittelyt</source>
-        <translation type="unfinished"></translation>
+        <translation>Print account-specific details</translation>
     </message>
 </context>
 <context>
@@ -7754,157 +7820,157 @@ Tarkasta kirjoittamasi avaimet.</source>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="14"/>
         <location filename="../kirjaus/muumuokkausdlg.cpp" line="87"/>
         <source>Uusi vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>New entry</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="26"/>
         <source>&amp;Päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Date</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="39"/>
         <source>&amp;Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Account</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="54"/>
         <source>Määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Quantity</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="62"/>
         <source>&amp;Debet</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Debit</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="69"/>
         <source>&amp;Kredit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Credit</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="102"/>
         <source>&amp;Sis. alv</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Incl. VAT</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="118"/>
         <source>Koh&amp;dennus</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;llocation</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="131"/>
         <source>Me&amp;rkkaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Ma&amp;rkings</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="144"/>
         <source>Tase-&amp;erä</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet it&amp;em</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="157"/>
         <source>Poistoaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Depreciation period</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="167"/>
         <source> vuotta</source>
-        <translation type="unfinished"></translation>
+        <translation> year(s)</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="174"/>
         <source>&amp;Jaksotus</source>
-        <translation type="unfinished"></translation>
+        <translation>Accr&amp;ual</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="189"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="208"/>
         <source>Kumppani</source>
-        <translation type="unfinished"></translation>
+        <translation>Partner</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="223"/>
         <source>Reskontra</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounts</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="229"/>
         <source>Ei reskontraa</source>
-        <translation type="unfinished"></translation>
+        <translation>No accounts</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="239"/>
         <source>Myyntireskontra</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounts receivable</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="246"/>
         <source>Ostoreskontra</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounts payable</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="292"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Alv-ilmoitus on jo annettu&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;VAT return has already been submitted&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="306"/>
         <source>Kirjaus on</source>
-        <translation type="unfinished"></translation>
+        <translation>Entry is</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="312"/>
         <source>Veron &amp;peruste</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax &amp;basis</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="319"/>
         <source>Veron m&amp;äärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax &amp;amount</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="326"/>
         <source>Vähe&amp;nnyksen määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Deduction &amp;amount</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="333"/>
         <source>Kohdentamaton maksuperusteinen alv</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated cash-based VAT</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="343"/>
         <source>Verok&amp;anta</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax &amp;rate</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="360"/>
         <source>&amp;Verolaji</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Tax type</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="372"/>
         <source>Kirjaa myös vero</source>
-        <translation type="unfinished"></translation>
+        <translation>Record tax as well</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="379"/>
         <source>Kirjaa myös vähennys</source>
-        <translation type="unfinished"></translation>
+        <translation>Record deduction as well</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.ui" line="418"/>
         <source>&amp;Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Description</translation>
     </message>
     <message>
         <location filename="../kirjaus/muumuokkausdlg.cpp" line="93"/>
         <source>Muokkaa vientiä</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit entry</translation>
     </message>
 </context>
 <context>
@@ -7912,102 +7978,102 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="38"/>
         <source>Kumoa</source>
-        <translation type="unfinished"></translation>
+        <translation>Undo</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="42"/>
         <source>Toista</source>
-        <translation type="unfinished"></translation>
+        <translation>Redo</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="49"/>
         <source>Leikkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Cut</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="53"/>
         <source>Kopioi</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="57"/>
         <source>Liitä</source>
-        <translation type="unfinished"></translation>
+        <translation>Paste</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="66"/>
         <source>Lihavoi</source>
-        <translation type="unfinished"></translation>
+        <translation>Bold</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="69"/>
         <source>Kursivoi</source>
-        <translation type="unfinished"></translation>
+        <translation>Italicize</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="74"/>
         <source>Lisää luettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Add list</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="76"/>
         <source>Lisää taulukko</source>
-        <translation type="unfinished"></translation>
+        <translation>Add table</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="81"/>
         <source>%1 saraketta</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 columns</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="87"/>
         <source>3 saraketta, tilikaudet</source>
-        <translation type="unfinished"></translation>
+        <translation>3 columns, accounting periods</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="95"/>
         <source>Lisää rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Add row</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="99"/>
         <source>Tasaa vasemmalle</source>
-        <translation type="unfinished"></translation>
+        <translation>Align left</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="100"/>
         <source>Tasaa keskelle</source>
-        <translation type="unfinished"></translation>
+        <translation>Align center</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="101"/>
         <source>Tasaa oikealle</source>
-        <translation type="unfinished"></translation>
+        <translation>Align right</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="120"/>
         <source>Muokkaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="134"/>
         <source>Leipäteksti</source>
-        <translation type="unfinished"></translation>
+        <translation>Body text</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="134"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="134"/>
         <source>Alaotsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Subheading</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/mytexteditor.cpp" line="134"/>
         <source>Kirjoituskone</source>
-        <translation type="unfinished"></translation>
+        <translation>Typewriter</translation>
     </message>
 </context>
 <context>
@@ -8015,77 +8081,77 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="97"/>
         <source>Tallenna liite</source>
-        <translation type="unfinished"></translation>
+        <translation>Save attachment</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="104"/>
         <source>Tiedoston tallentaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Saving file</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="105"/>
         <source>Tiedostoon %1 kirjoittaminen epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to write to file %1.</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="130"/>
         <source>Tiedoston avaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Open file</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="130"/>
         <source>%1-tiedostoja näyttävän ohjelman käynnistäminen ei onnistunut</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to launch the program to display %1 files</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="264"/>
         <source>liite.jpg</source>
-        <translation type="unfinished"></translation>
+        <translation>attachment.jpg</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="266"/>
         <source>liite.png</source>
-        <translation type="unfinished"></translation>
+        <translation>attachment.png</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="328"/>
         <source>Ladataan...</source>
-        <translation type="unfinished"></translation>
+        <translation>Loading...</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="363"/>
         <source>Sovita leveyteen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fit to width</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="366"/>
         <source>Sovita sivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Fit page</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="369"/>
         <source>Suurenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom in</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="373"/>
         <source>Pienennä</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom out</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="377"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="380"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../liite/naytaliitewidget.cpp" line="383"/>
         <source>Avaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
 </context>
 <context>
@@ -8093,7 +8159,7 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../naytin/kuvaview.h" line="31"/>
         <source>jpg-kuva (*.jpg)</source>
-        <translation type="unfinished"></translation>
+        <translation>jpg image (*.jpg)</translation>
     </message>
 </context>
 <context>
@@ -8101,7 +8167,7 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../naytin/laaditunraportinnaytin.cpp" line="44"/>
         <source>Tyhjä raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>Empty report</translation>
     </message>
 </context>
 <context>
@@ -8109,7 +8175,7 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../naytin/pdfnaytin.h" line="20"/>
         <source>Pdf-tiedosto (*.pdf)</source>
-        <translation type="unfinished"></translation>
+        <translation>Pdf file (*.pdf)</translation>
     </message>
 </context>
 <context>
@@ -8117,7 +8183,7 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../naytin/printpreviewnaytin.h" line="39"/>
         <source>pdf-tiedosto (*.pdf)</source>
-        <translation type="unfinished"></translation>
+        <translation>pdf file (*.pdf)</translation>
     </message>
 </context>
 <context>
@@ -8125,7 +8191,7 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../naytin/tekstinaytin.h" line="37"/>
         <source>tekstitiedosto (*.txt)</source>
-        <translation type="unfinished"></translation>
+        <translation>text file (*.txt)</translation>
     </message>
 </context>
 <context>
@@ -8133,109 +8199,109 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="95"/>
         <source>Tiedostoa %1 ei voi avata</source>
-        <translation type="unfinished"></translation>
+        <translation>Cannot open file %1</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="176"/>
         <source>Raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>Report</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="183"/>
         <source>Ikkuna</source>
-        <translation type="unfinished"></translation>
+        <translation>Window</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="186"/>
         <source>Sulje</source>
-        <translation type="unfinished"></translation>
+        <translation>Close</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="94"/>
         <source>Virhe tiedoston näyttämisessä</source>
-        <translation type="unfinished"></translation>
+        <translation>Error displaying file</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="176"/>
         <source>Tekemilläsi valinnoilla muodostuu tyhjä raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>Your selections result in an empty report</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="191"/>
         <source>Päivitä</source>
-        <translation type="unfinished"></translation>
+        <translation>Update</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="197"/>
         <source>Avaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="200"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="205"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="210"/>
         <source>Raidat</source>
-        <translation type="unfinished"></translation>
+        <translation>Stripes</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="214"/>
         <source>Sivun asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Page settings</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="221"/>
         <source>HTML</source>
-        <translation type="unfinished"></translation>
+        <translation>HTML</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="226"/>
         <source>Avaa selaimella</source>
-        <translation type="unfinished"></translation>
+        <translation>Open in browser</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="230"/>
         <location filename="../naytin/naytinikkuna.cpp" line="247"/>
         <source>Leikepöydälle</source>
-        <translation type="unfinished"></translation>
+        <translation>To clipboard</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="272"/>
         <source>Pienennä</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom out</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="234"/>
         <location filename="../naytin/naytinikkuna.cpp" line="250"/>
         <source>Tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>To file</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="241"/>
         <source>CSV</source>
-        <translation type="unfinished"></translation>
+        <translation>CSV</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="255"/>
         <source>CSV:n muoto</source>
-        <translation type="unfinished"></translation>
+        <translation>CSV format</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="264"/>
         <source>Sovita</source>
-        <translation type="unfinished"></translation>
+        <translation>Fit</translation>
     </message>
     <message>
         <location filename="../naytin/naytinikkuna.cpp" line="268"/>
         <source>Suurenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom in</translation>
     </message>
 </context>
 <context>
@@ -8243,77 +8309,77 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../naytin/naytinview.cpp" line="199"/>
         <source>Tiedoston avaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Open file</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="71"/>
         <source>Sovita leveyteen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fit to width</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="75"/>
         <source>Suurenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom in</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="79"/>
         <source>Pienennä</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom out</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="83"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="86"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="89"/>
         <source>Avaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="199"/>
         <source>%1-tiedostoja näyttävän ohjelman käynnistäminen ei onnistunut</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to launch the program to display %1 files</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="205"/>
         <location filename="../naytin/naytinview.cpp" line="253"/>
         <source>Tallenna tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Save to file</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="213"/>
         <source>Tiedoston tallentaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Saving file</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="214"/>
         <location filename="../naytin/naytinview.cpp" line="262"/>
         <location filename="../naytin/naytinview.cpp" line="339"/>
         <source>Tiedostoon %1 kirjoittaminen epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to write to file %1.</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="247"/>
         <location filename="../naytin/naytinview.cpp" line="349"/>
         <source>Viety leikepöydälle</source>
-        <translation type="unfinished"></translation>
+        <translation>Exported to clipboard</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="261"/>
         <location filename="../naytin/naytinview.cpp" line="338"/>
         <source>Tiedoston vieminen</source>
-        <translation type="unfinished"></translation>
+        <translation>File export</translation>
     </message>
     <message>
         <location filename="../naytin/naytinview.cpp" line="330"/>
         <source>Vie csv-tiedostoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Export to CSV file</translation>
     </message>
 </context>
 <context>
@@ -8321,209 +8387,209 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="62"/>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="80"/>
         <source>Kaikki kirjanpito-oikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>All accounting permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="91"/>
         <source>Tositteet</source>
-        <translation type="unfinished"></translation>
+        <translation>Vouchers</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="97"/>
         <source>Kaikki tositeoikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>All voucher permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="100"/>
         <source>RT</source>
-        <translation type="unfinished"></translation>
+        <translation>RT</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="107"/>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="178"/>
         <source>Selaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Browsing</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="120"/>
         <source>Kommentointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Commenting</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="133"/>
         <source>Luonnoksen laatiminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Drafting</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="146"/>
         <source>Tallentaminen ja muokkaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Saving and editing</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="162"/>
         <source>Laskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="168"/>
         <source>Kaikki laskuoikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>All invoice permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="171"/>
         <source>RL</source>
-        <translation type="unfinished"></translation>
+        <translation>RL</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="188"/>
         <source>Laskun laatiminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating an invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="198"/>
         <source>Laskun lähettäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Sending an invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="208"/>
         <source>Tuotteiden muokkaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Editing products</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="218"/>
         <source>Ryhmien muokkaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit groups</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="256"/>
         <source>Laskujen kierto</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice circulation</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="262"/>
         <source>Kaikki kierron oikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>All circulation permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="265"/>
         <source>RK</source>
-        <translation type="unfinished"></translation>
+        <translation>RK</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="272"/>
         <source>Laskun lisääminen kiertoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Adding an invoice to circulation</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="282"/>
         <source>Laskun tarkastaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Reviewing an invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="292"/>
         <source>Laskun hyväksyminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Approving an invoice</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="302"/>
         <source>Kaikkien kiertojen selaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Browsing all cycles</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="321"/>
         <source>Raportit</source>
-        <translation type="unfinished"></translation>
+        <translation>Reports</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="327"/>
         <source>Raporttien tulostaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Printing reports</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="340"/>
         <source>Työkalut</source>
-        <translation type="unfinished"></translation>
+        <translation>Tools</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="346"/>
         <source>Kaikki työkaluoikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>All tool permissions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="349"/>
         <source>RO</source>
-        <translation type="unfinished"></translation>
+        <translation>RO</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="356"/>
         <source>Arvolisäveroilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Value Added Tax declaration</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="366"/>
         <source>Budjetin muokkaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Editing the budget</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="376"/>
         <source>Tilinpäätöksen tekeminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating financial statements</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="407"/>
         <source>Asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="419"/>
         <source>Asetusten muokkaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Modifying settings</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="435"/>
         <source>Perusasetusten muokkaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Modifying basic settings</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="438"/>
         <source>Ab</source>
-        <translation type="unfinished"></translation>
+        <translation>Ab</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="451"/>
         <source>Lisäosien asetukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Add-on settings</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="454"/>
         <source>Ao</source>
-        <translation type="unfinished"></translation>
+        <translation>Ao</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="467"/>
         <source>Lisäosien toiminnot</source>
-        <translation type="unfinished"></translation>
+        <translation>Add-on functions</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="470"/>
         <source>Ad</source>
-        <translation type="unfinished"></translation>
+        <translation>Ad</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="490"/>
         <source>Käyttöoikeudet</source>
-        <translation type="unfinished"></translation>
+        <translation>User Rights</translation>
     </message>
     <message>
         <location filename="../maaritys/kayttooikeudet/oikeuswidget.ui" line="502"/>
         <source>Käyttöoikeuksien myöntäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Granting user permissions</translation>
     </message>
 </context>
 <context>
@@ -8531,59 +8597,59 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="22"/>
         <source>Kirjattaessa</source>
-        <translation type="unfinished"></translation>
+        <translation>When recording</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="28"/>
         <location filename="../maaritys/oletustilimaaritys.ui" line="94"/>
         <source>Tulot</source>
-        <translation type="unfinished"></translation>
+        <translation>Income</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="48"/>
         <location filename="../maaritys/oletustilimaaritys.ui" line="117"/>
         <source>Menot</source>
-        <translation type="unfinished"></translation>
+        <translation>Expenses</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="88"/>
         <source>Tiliotteelta tuotaessa</source>
-        <translation type="unfinished"></translation>
+        <translation>When importing from bank statement</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="110"/>
         <source>TilioteTuloKaytossa</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank statement income in use</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="133"/>
         <source>TilioteMenoKaytossa</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank statement expense in use</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="140"/>
         <source>Pankin palvelumaksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank service fees</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="160"/>
         <source>Korkotulot</source>
-        <translation type="unfinished"></translation>
+        <translation>Interest income</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="180"/>
         <source>Korkomenot</source>
-        <translation type="unfinished"></translation>
+        <translation>Interest expenses</translation>
     </message>
     <message>
         <location filename="../maaritys/oletustilimaaritys.ui" line="200"/>
         <source>Pankkikorttiostot</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit card purchases</translation>
     </message>
 </context>
 <context>
@@ -8591,117 +8657,117 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../raportti/paivakirja.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="22"/>
         <source>Alkupäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Start date</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="36"/>
         <source>Loppupäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>End date</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="50"/>
         <source>Kohdennuksella</source>
-        <translation type="unfinished"></translation>
+        <translation>With Allocation</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="68"/>
         <source>Ote tililtä</source>
-        <translation type="unfinished"></translation>
+        <translation>Account Statement</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="86"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="96"/>
         <source>Kuvanlaatu</source>
-        <translation type="unfinished"></translation>
+        <translation>Image Quality</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="108"/>
         <source>Poimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Select</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="114"/>
         <source>Kaikki</source>
-        <translation type="unfinished"></translation>
+        <translation>All</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="124"/>
         <source>Tulot</source>
-        <translation type="unfinished"></translation>
+        <translation>Income</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="135"/>
         <source>Menot</source>
-        <translation type="unfinished"></translation>
+        <translation>Expenses</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="149"/>
         <source>Tulostusjärjestys</source>
-        <translation type="unfinished"></translation>
+        <translation>Print Order</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="155"/>
         <source>Päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="169"/>
         <source>Tositenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher Number</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="183"/>
         <source>Tulosta asiakas/toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Print Customer/Supplier</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="194"/>
         <source>Tulosta kohdennukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Print Allocations</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="205"/>
         <source>Tulosta alv-prosentti</source>
-        <translation type="unfinished"></translation>
+        <translation>Print VAT Percentage</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="216"/>
         <source>Ryhmittele tositelajeittain</source>
-        <translation type="unfinished"></translation>
+        <translation>Group by Voucher Type</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="227"/>
         <source>Tulosta summarivit</source>
-        <translation type="unfinished"></translation>
+        <translation>Print Summary Rows</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="238"/>
         <source>Erittele päivät tyhjällä rivillä</source>
-        <translation type="unfinished"></translation>
+        <translation>Separate Days with Empty Row</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="249"/>
         <source>Älä näytä nollasaldoja</source>
-        <translation type="unfinished"></translation>
+        <translation>Do not show zero balances</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="260"/>
         <source>Näytä erittelemättömien viennit</source>
-        <translation type="unfinished"></translation>
+        <translation>Show unspecified entries</translation>
     </message>
     <message>
         <location filename="../raportti/paivakirja.ui" line="286"/>
         <source>Tase-erien selvittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet item reconciliation</translation>
     </message>
 </context>
 <context>
@@ -8709,13 +8775,14 @@ Tarkasta kirjoittamasi avaimet.</source>
     <message>
         <location filename="../maaritys/paivitetaandlg.ui" line="14"/>
         <source>Tilikartan päivitys</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts update</translation>
     </message>
     <message>
         <location filename="../maaritys/paivitetaandlg.ui" line="30"/>
         <source>Tilikarttaa päivitetään uusimpaan versioon.
 Odota...</source>
-        <translation type="unfinished"></translation>
+        <translation>Updating the chart of accounts to the latest version.
+Please wait...</translation>
     </message>
 </context>
 <context>
@@ -8723,7 +8790,7 @@ Odota...</source>
     <message>
         <location filename="../pilvi/paivitysinfo.cpp" line="69"/>
         <source>Palvelimeen ei saada yhteyttä</source>
-        <translation type="unfinished"></translation>
+        <translation>Unable to connect to the server</translation>
     </message>
 </context>
 <context>
@@ -8731,108 +8798,109 @@ Odota...</source>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="25"/>
         <source>Palkat ja korvaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Salaries and compensations</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="31"/>
         <source>Päivärahat</source>
-        <translation type="unfinished"></translation>
+        <translation>Daily allowances</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="51"/>
         <source>Palkkiot</source>
-        <translation type="unfinished"></translation>
+        <translation>Fees</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="61"/>
         <source>Luontoisedut</source>
-        <translation type="unfinished"></translation>
+        <translation>Fringe benefits</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="71"/>
         <source>Kilometrikorvaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Mileage allowances</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="81"/>
         <source>Lisät ja korvaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Supplements and compensations</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="94"/>
         <source>Ateriakorvaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Meal allowances</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="113"/>
         <source>Palkat</source>
-        <translation type="unfinished"></translation>
+        <translation>Salaries</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="123"/>
         <source>Loma-ajan ja 
 sosiaalipalkat</source>
-        <translation type="unfinished"></translation>
+        <translation>Holiday pay and 
+social salaries</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="166"/>
         <source>Työntekijöiden maksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Employee contributions</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="172"/>
         <source>Ennakonpidätykset</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax withholdings</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="185"/>
         <source>Eläkevakuutusmaksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Pension insurance contributions</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="198"/>
         <source>Työttömyysvakuutusmaksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Unemployment insurance contributions</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="211"/>
         <source>Ay-jäsenmaksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Union membership fees</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="224"/>
         <source>Ulosottotilitykset</source>
-        <translation type="unfinished"></translation>
+        <translation>Garnishment payments</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="237"/>
         <source>Työnantajan maksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Employer contributions</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="243"/>
         <source>Sairausvakuutusmaksu</source>
-        <translation type="unfinished"></translation>
+        <translation>Health insurance contribution</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="261"/>
         <source>Vastatili</source>
-        <translation type="unfinished"></translation>
+        <translation>Contra account</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="271"/>
         <source>Tililtä maksetaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Paid from account</translation>
     </message>
     <message>
         <location filename="../apuri/palkkaapuri.ui" line="298"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
 </context>
 <context>
@@ -8840,103 +8908,103 @@ sosiaalipalkat</source>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="22"/>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="35"/>
         <source>Palkat</source>
-        <translation type="unfinished"></translation>
+        <translation>Salaries</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="45"/>
         <source>Lisät</source>
-        <translation type="unfinished"></translation>
+        <translation>Supplements</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="69"/>
         <source>Luontoisedut</source>
-        <translation type="unfinished"></translation>
+        <translation>Fringe benefits</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="79"/>
         <source>Palkkiot</source>
-        <translation type="unfinished"></translation>
+        <translation>Fees</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="96"/>
         <source>Luontoisetujen vastatili</source>
-        <translation type="unfinished"></translation>
+        <translation>Offset account for fringe benefits</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="113"/>
         <source>Loma-ajan ja sosiaalipalkat</source>
-        <translation type="unfinished"></translation>
+        <translation>Holiday and social salaries</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="130"/>
         <source>Korvaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Compensations</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="136"/>
         <source>Kilometrikorvaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Mileage allowances</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="153"/>
         <source>Päivärahat</source>
-        <translation type="unfinished"></translation>
+        <translation>Daily allowances</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="170"/>
         <source>Ateriakorvaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Meal allowances</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="207"/>
         <source>Työntekijöiden maksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Employee contributions</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="237"/>
         <source>Ay-jäsenmaksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Union membership fees</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="247"/>
         <source>Työntekijöiden TVR-maksut</source>
-        <translation type="unfinished"></translation>
+        <translation>Employee unemployment insurance contributions</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="271"/>
         <source>Ennakonpidätys</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax withholding</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="213"/>
         <source>Työntekijöiden eläkevakuutusmaksu</source>
-        <translation type="unfinished"></translation>
+        <translation>Employee pension insurance contribution</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="281"/>
         <source>Ulosottotilitykset</source>
-        <translation type="unfinished"></translation>
+        <translation>Garnishment payments</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="298"/>
         <source>Sairausvakuutusmaksu</source>
-        <translation type="unfinished"></translation>
+        <translation>Health insurance contribution</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="304"/>
         <source>Kirjaustili</source>
-        <translation type="unfinished"></translation>
+        <translation>Posting account</translation>
     </message>
     <message>
         <location filename="../maaritys/palkkatilimaaritys.ui" line="314"/>
         <source>Vastatili</source>
-        <translation type="unfinished"></translation>
+        <translation>Contra account</translation>
     </message>
 </context>
 <context>
@@ -8944,17 +9012,17 @@ sosiaalipalkat</source>
     <message>
         <location filename="../laskutus/toimittaja/pdftoimittaja.cpp" line="36"/>
         <source>Valitse laskujen tallennushakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Select invoice save directory</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/pdftoimittaja.cpp" line="41"/>
         <source>Laskun tallentaminen peruttiin</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice saving was cancelled</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/pdftoimittaja.cpp" line="60"/>
         <source>Laskutiedoston kirjoittaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to write invoice file</translation>
     </message>
 </context>
 <context>
@@ -8962,112 +9030,112 @@ sosiaalipalkat</source>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="25"/>
         <source>Perusvalinnat</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic settings</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="34"/>
         <source>Organisaatio</source>
-        <translation type="unfinished"></translation>
+        <translation>Organization</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="51"/>
         <source>Y-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="71"/>
         <source>Yritysmuoto</source>
-        <translation type="unfinished"></translation>
+        <translation>Company form</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="88"/>
         <source>Laajuus</source>
-        <translation type="unfinished"></translation>
+        <translation>Scope</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="138"/>
         <source>Vaihda</source>
-        <translation type="unfinished"></translation>
+        <translation>Change</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="105"/>
         <source>Kotipaikka</source>
-        <translation type="unfinished"></translation>
+        <translation>Domicile</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="178"/>
         <source>Tiedoston sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>File location</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="191"/>
         <source>Avaa hakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Open directory</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="251"/>
         <source>Arkiston sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Archive location</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="155"/>
         <source>Avaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="123"/>
         <source>Alias</source>
-        <translation type="unfinished"></translation>
+        <translation>Alias</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="241"/>
         <source>Tilikartta</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="261"/>
         <source>Kirjanpidon koko</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting Size</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="278"/>
         <source>Määritä alias</source>
-        <translation type="unfinished"></translation>
+        <translation>Define Alias</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="293"/>
         <source>Arvonlisäverovelvollinen</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT Liable</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="300"/>
         <source>AlvVelvollinen</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT Liable</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="317"/>
         <source>alkaen</source>
-        <translation type="unfinished"></translation>
+        <translation>starting from</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="339"/>
         <source>Harjoituskirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Practice accounting</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.ui" line="346"/>
         <source>Harjoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Practice</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.cpp" line="135"/>
         <source>Vastuu kirjanpidosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Responsibility for accounting</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.cpp" line="136"/>
@@ -9076,12 +9144,16 @@ sosiaalipalkat</source>
 Ohjelmalla ei ole mitään takuuta. Kitsas Oy ei myöskään anna oikeudellista neuvontaa kirjanpidosta tai verotuksesta.
 
 Käänny tarvittaessa kirjanpidon ammattilaisen puoleen</source>
-        <translation type="unfinished"></translation>
+        <translation>You are responsible for the accuracy and legality of your accounting and for ensuring that all taxes are paid properly.
+
+The software comes with no warranty. Kitsas Oy also does not provide legal advice on accounting or taxation.
+
+Consult an accounting professional if necessary</translation>
     </message>
     <message>
         <location filename="../maaritys/perusvalinnat.cpp" line="170"/>
         <source>%L1 Mt</source>
-        <translation type="unfinished"></translation>
+        <translation>%L1 MB</translation>
     </message>
 </context>
 <context>
@@ -9089,66 +9161,70 @@ Käänny tarvittaessa kirjanpidon ammattilaisen puoleen</source>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="17"/>
         <source>Kirjanpidon kopiointi pilveen</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying accounting to the cloud</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="36"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="65"/>
         <source>Tämä toiminto kopioi nykyisen kirjanpitosi Kitsaan pilveen. Tämän jälkeen kirjanpito varmuuskopioidaan automaattisesti, voit käyttää laskujen kierrätystä ja kirjanpitoa voidaan käsitellä monelta tietokoneelta.
 
 Nykyinen kirjanpitotiedosto jää edelleen tietokoneellesi.</source>
-        <translation type="unfinished"></translation>
+        <translation>This function copies your current accounting to Kitsas cloud. After this, the accounting will be automatically backed up, you can use invoice recycling, and the accounting can be processed from multiple computers.
+
+The current accounting file will remain on your computer.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="99"/>
         <source>Kirjanpidon sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting location</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="105"/>
         <source>Henkilökohtainen kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Personal accounting</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="122"/>
         <source>Tilitoimiston kirjahylly</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting firm&apos;s bookshelf</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="135"/>
         <source>Tilitoimisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting firm</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="152"/>
         <source>Kirjahylly</source>
-        <translation type="unfinished"></translation>
+        <translation>Bookshelf</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="224"/>
         <source>Kopioidaan tilikarttaa ja asetuksia</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying chart of accounts and settings</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="247"/>
         <source>Kopioidaan tositteita</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying vouchers</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="257"/>
         <source>Kopioidaan liitteitä</source>
-        <translation type="unfinished"></translation>
+        <translation>Copying attachments</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="283"/>
         <source>Kirjanpitosi on kopioitu Kitsaan pilveen.
 
 Myös paikallinen kirjanpitotiedosto on edelleen jäljellä. Huomaathan, että paikalliseen kirjanpitoon tehdyt muokkaukset eivät muuta pilvessä olevaa kirjanpitoa. Pilvessä olevaa kirjanpitoa ei voi myöskään voi muuntaa takaisin paikalliseksi kirjanpitotiedostoksi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Your accounting has been copied to Kitsas cloud.
+
+The local accounting file still remains. Please note that changes made to the local accounting do not modify the accounting in the cloud. The accounting in the cloud cannot be converted back to a local accounting file.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.ui" line="319"/>
@@ -9156,29 +9232,34 @@ Myös paikallinen kirjanpitotiedosto on edelleen jäljellä. Huomaathan, että p
 
 Kirjanpidossa on yli 10 megatavun kokoisia liitteitä, joita ei voi 
 tallentaa Kitsaan pilveen.</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting cannot be transferred to the cloud. 
+
+The accounting contains attachments larger than 10 megabytes, which cannot be 
+saved to Kitsas cloud.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.cpp" line="594"/>
         <source>Kirjanpidon tallentamisesta pilveen veloitetaan %1/kk</source>
-        <translation type="unfinished"></translation>
+        <translation>Cloud storage for bookkeeping is charged at %1/month</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.cpp" line="597"/>
         <source>Sinun pitää päivittää tilauksesi ennen kuin voit kopioida tämän kirjanpidon pilveen.</source>
-        <translation type="unfinished"></translation>
+        <translation>You need to upgrade your subscription before you can copy this accounting to the cloud.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.cpp" line="487"/>
         <source>Tositteita kopioitu %1 kpl, kirjanpidon koko pilvessä %L2 Mt</source>
-        <translation type="unfinished"></translation>
+        <translation>Copied %1 vouchers, accounting size in the cloud %L2 MB</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.cpp" line="507"/>
         <source>Kirjanpidon siirto pilveen epäonnistui.
 
 Kaikkia tositteita ei saatu siirrettyä pilveen.</source>
-        <translation type="unfinished"></translation>
+        <translation>The transfer of accounting to the cloud failed.
+
+Not all vouchers could be transferred to the cloud.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.cpp" line="510"/>
@@ -9187,12 +9268,16 @@ Kaikkia tositteita ei saatu siirrettyä pilveen.</source>
 Kirjanpitoa on mahdollisesti käsitelty sellaisella ohjelman versiolla, jonka jäljiltä tallenteessa on vähäinen tekninen virhe, joka on havaittu pilvipalvelun tarkemmissa tarkastuksissa.
 
 Tämän kirjanpidon kopioiminen pilveen vaatii kirjanpidon korjaamista ohjelmiston tuen tai muun asiantuntijan avulla.</source>
-        <translation type="unfinished"></translation>
+        <translation>The transfer of accounting to the cloud failed.
+
+The accounting may have been processed with a version of the program that left a minor technical error in the record, which was detected in more detailed checks by the cloud service.
+
+Copying this accounting to the cloud requires correcting the accounting with the help of software support or another expert.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilveensiirto.cpp" line="517"/>
         <source>Kirjanpidon siirto pilveen epäonnistui virheen %1 takia</source>
-        <translation type="unfinished"></translation>
+        <translation>The transfer of accounting to the cloud failed due to error %1</translation>
     </message>
 </context>
 <context>
@@ -9200,37 +9285,37 @@ Tämän kirjanpidon kopioiminen pilveen vaatii kirjanpidon korjaamista ohjelmist
     <message>
         <location filename="../pilvi/pilvikysely.cpp" line="162"/>
         <source>&lt;b&gt;Verkkovirhe %1&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Network error %1&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvikysely.cpp" line="158"/>
         <source>&lt;b&gt;Palvelimeen ei saada yhteyttä&lt;/b&gt;&lt;br&gt;Palvelin on ehkä tilapäisesti poissa käytöstä</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Cannot connect to the server&lt;/b&gt;&lt;br&gt;The server may be temporarily unavailable</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvikysely.cpp" line="160"/>
         <source>&lt;b&gt;Häiriö verkkoyhteydessä&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Network connection disruption&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvikysely.cpp" line="164"/>
         <source>&lt;b&gt;Oikeutesi eivät riitä tähän toimintoon&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Your permissions are not sufficient for this function&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvikysely.cpp" line="166"/>
         <source>&lt;b&gt;Palvelinvirhe&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Server error&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvikysely.cpp" line="168"/>
         <source>&lt;b&gt;Virhe palvelimella&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Server Error&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvikysely.cpp" line="170"/>
         <source>&lt;b&gt;Palvelinvirhe&lt;/b&gt;&lt;br&gt;Palvelu on ehkä tilapäisesti poissa käytöstä</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Server Error&lt;/b&gt;&lt;br&gt;The service may be temporarily unavailable</translation>
     </message>
 </context>
 <context>
@@ -9238,75 +9323,76 @@ Tämän kirjanpidon kopioiminen pilveen vaatii kirjanpidon korjaamista ohjelmist
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="97"/>
         <source>Kirjanpitoa luodaan...</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating accounting...</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="97"/>
         <location filename="../pilvi/pilvimodel.cpp" line="193"/>
         <location filename="../pilvi/pilvimodel.cpp" line="392"/>
         <source>Keskeytä</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="104"/>
         <source>Kirjanpidon luominen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create accounting</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="105"/>
         <source>Kirjanpitoa luotaessa tapahtui virhe:
 %1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>An error occurred while creating accounting:
+%1 %2</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="193"/>
         <source>Kirjanpitoa avataan...</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening accounting...</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="392"/>
         <source>Kirjanpitoa alustetaan...</source>
-        <translation type="unfinished"></translation>
+        <translation>Initializing accounting...</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="404"/>
         <source>Kirjanpidon avaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening accounting</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="404"/>
         <source>Kirjanpitoa %1 ei ole vielä alustettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting %1 has not been initialized yet</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="446"/>
         <source>Kirjanpidon alustaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to initialize accounting</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="447"/>
         <source>Virhe palvelimella kirjanpitoa alustettaessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Server error while initializing accounting</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="456"/>
         <source>Kirjanpidon avaaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to open accounting</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="477"/>
         <source>Tilapäinen virhe verkkoyhteydessä tai palvelimella. Tarkasta verkkoyhteys ja yritä vähän ajan kuluttua uudelleen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Temporary error in network connection or server. Check your network connection and try again in a moment.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="479"/>
         <source>Kirjanpidon avaamiseen ei ole oikeutta. Tarkasta käyttöoikeus ja kirjaudu uudelleen.</source>
-        <translation type="unfinished"></translation>
+        <translation>You don&apos;t have permission to open the accounting. Check your access rights and log in again.</translation>
     </message>
     <message>
         <location filename="../pilvi/pilvimodel.cpp" line="481"/>
         <source>Virhe kirjanpidon avaamisessa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error opening accounting.</translation>
     </message>
 </context>
 <context>
@@ -9314,22 +9400,22 @@ Tämän kirjanpidon kopioiminen pilveen vaatii kirjanpidon korjaamista ohjelmist
     <message>
         <location filename="../tilaus/planmodel.cpp" line="35"/>
         <source>Paketti</source>
-        <translation type="unfinished"></translation>
+        <translation>Package</translation>
     </message>
     <message>
         <location filename="../tilaus/planmodel.cpp" line="37"/>
         <source>Hinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Price</translation>
     </message>
     <message>
         <location filename="../tilaus/planmodel.cpp" line="73"/>
         <source>%L1 € / 6 kk</source>
-        <translation type="unfinished"></translation>
+        <translation>%L1 € / 6 months</translation>
     </message>
     <message>
         <location filename="../tilaus/planmodel.cpp" line="76"/>
         <source>%L1 € / vuosi</source>
-        <translation type="unfinished"></translation>
+        <translation>%L1 € / year</translation>
     </message>
 </context>
 <context>
@@ -9337,28 +9423,28 @@ Tämän kirjanpidon kopioiminen pilveen vaatii kirjanpidon korjaamista ohjelmist
     <message>
         <location filename="../arkisto/poistaja.ui" line="14"/>
         <source>Suunnitelman mukaiset poistot</source>
-        <translation type="unfinished"></translation>
+        <translation>Planned depreciation</translation>
     </message>
     <message>
         <location filename="../arkisto/poistaja.ui" line="24"/>
         <source>Vahvista suunnitelman mukaiset poistot</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm planned depreciation</translation>
     </message>
     <message>
         <location filename="../arkisto/poistaja.cpp" line="73"/>
         <location filename="../arkisto/poistaja.cpp" line="78"/>
         <source>Tilikarttavirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts error</translation>
     </message>
     <message>
         <location filename="../arkisto/poistaja.cpp" line="73"/>
         <source>Tili %1 puuttuu</source>
-        <translation type="unfinished"></translation>
+        <translation>Account %1 is missing</translation>
     </message>
     <message>
         <location filename="../arkisto/poistaja.cpp" line="79"/>
         <source>Tilille %1 ei ole määritelty kelvollista poistotiliä. Poistojen automaattikirjaamista ei voi tehdä.</source>
-        <translation type="unfinished"></translation>
+        <translation>No valid depreciation account has been defined for account %1. Automatic recording of depreciation cannot be done.</translation>
     </message>
 </context>
 <context>
@@ -9366,82 +9452,84 @@ Tämän kirjanpidon kopioiminen pilveen vaatii kirjanpidon korjaamista ohjelmist
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="14"/>
         <source>Tilinavauksen tuonti Procountorista</source>
-        <translation type="unfinished"></translation>
+        <translation>Import opening balance from Procountor</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="27"/>
         <source>Lisää tuotavat tiedostot</source>
-        <translation type="unfinished"></translation>
+        <translation>Add files to import</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="47"/>
         <source>Valitse tiedosto...</source>
-        <translation type="unfinished"></translation>
+        <translation>Select file...</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="62"/>
         <source>Edellinen tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous accounting period</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="113"/>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="198"/>
         <source>- Tase</source>
-        <translation type="unfinished"></translation>
+        <translation>- Balance sheet</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="86"/>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="152"/>
         <source>- Tuloslaskelma</source>
-        <translation type="unfinished"></translation>
+        <translation>- Income statement</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="78"/>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="183"/>
         <source>Debet ja kredit 
 eivät täsmää</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit and credit 
+do not match</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="136"/>
         <source>Nykyinen tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Current accounting period</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.ui" line="172"/>
         <source>Oikaise taseesta 
 edellinen tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Adjust previous accounting period 
+from balance sheet</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="52"/>
         <source>Tuo alkusaldot tiedostosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Import opening balances from file</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="53"/>
         <source>CSV-tiedostot (*.csv);;Kaikki tiedostot(*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>CSV files (*.csv);;All files(*.*)</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="67"/>
         <source>Tase</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="67"/>
         <source>Tuloslaskelma</source>
-        <translation type="unfinished"></translation>
+        <translation>Income statement</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="68"/>
         <source>edellinen</source>
-        <translation type="unfinished"></translation>
+        <translation>previous</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="68"/>
         <source>nykyinen</source>
-        <translation type="unfinished"></translation>
+        <translation>current</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="70"/>
@@ -9450,59 +9538,59 @@ edellinen tilikausi</source>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="98"/>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="100"/>
         <source>Procountor-tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>Procountor import</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="70"/>
         <source>Samankaltainen avaustiedosto (%2 %3 tilikausi) on jo lisätty. Tätä tiedostoa %1 ei käytetä.</source>
-        <translation type="unfinished"></translation>
+        <translation>A similar opening file (%2 %3 accounting period) has already been added. This file %1 will not be used.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="94"/>
         <source>Tiedosto %1 ei ole muodoltaan oikeanlainen. Muodosta tuontitiedostot Procountorissa ohjeen mukaisesti.</source>
-        <translation type="unfinished"></translation>
+        <translation>File %1 is not in the correct format. Create import files in Procountor according to the instructions.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="96"/>
         <source>Tiedostossa %1 olevat tilikaudet eivät vastaa Kitsaassa määriteltyjä kahta ensimmäistä tilikautta.</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting periods in file %1 do not match the first two accounting periods defined in Kitsas.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="98"/>
         <source>Tiedoston %1 lukeminen ei onnistunut tiedostovirheen takia.</source>
-        <translation type="unfinished"></translation>
+        <translation>Reading file %1 failed due to a file error.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="100"/>
         <source>Tiedosto %1 ei ole muodoltaan oikea - päivämääriä ei löydetty.</source>
-        <translation type="unfinished"></translation>
+        <translation>File %1 does not have the correct format - no dates were found.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="192"/>
         <source>Tilinavaus Procountorista (keskeneräinen tilikausi)</source>
-        <translation type="unfinished"></translation>
+        <translation>Account opening from Procountor (incomplete accounting period)</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="203"/>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="207"/>
         <source>Aloitussaldojen tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>Import of opening balances</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="204"/>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="208"/>
         <source>Keskeneräisen tilikauden saldoista on muodostettu tosite päivämäärällä %1</source>
-        <translation type="unfinished"></translation>
+        <translation>A voucher has been created from the balances of the incomplete accounting period with the date %1</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontidialog.cpp" line="210"/>
         <source>Näiden saldojen debet ja kredit ei täsmää, joten tosite löytyy Selaa-toiminnon Luonnokset-välilehdeltä.</source>
-        <translation type="unfinished"></translation>
+        <translation>The debit and credit of these balances do not match, so the voucher can be found in the Drafts tab of the Browse function.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/procountor/procountortuontitiedosto.cpp" line="175"/>
         <source>Procountorista %3 %1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>From Procountor %3 %1 %2</translation>
     </message>
 </context>
 <context>
@@ -9510,22 +9598,22 @@ edellinen tilikausi</source>
     <message>
         <location filename="../raportti/pvmvali.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../raportti/pvmvali.ui" line="22"/>
         <source>Alkupäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Start date</translation>
     </message>
     <message>
         <location filename="../raportti/pvmvali.ui" line="36"/>
         <source>Loppupäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>End date</translation>
     </message>
     <message>
         <location filename="../raportti/pvmvali.ui" line="50"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
 </context>
 <context>
@@ -9533,53 +9621,54 @@ edellinen tilikausi</source>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="29"/>
         <source>Muokkaa raporttia </source>
-        <translation type="unfinished"></translation>
+        <translation>Edit report </translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="43"/>
         <source>Kopioi</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="67"/>
         <source>Nimike</source>
-        <translation type="unfinished"></translation>
+        <translation>Item</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="98"/>
         <source>Lisää rivi ennen</source>
-        <translation type="unfinished"></translation>
+        <translation>Add row before</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="109"/>
         <source>Lisää rivi jälkeen</source>
-        <translation type="unfinished"></translation>
+        <translation>Add row after</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="120"/>
         <source>Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.ui" line="131"/>
         <source>Poista rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete row</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.cpp" line="129"/>
         <source>Raportin kopioiminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy report</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkaus.cpp" line="129"/>
         <source>Anna uuden raportin tunnus. 
 Tunnusta ei näytetä käyttäjälle</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter new report identifier. 
+The identifier is not shown to the user</translation>
     </message>
 </context>
 <context>
@@ -9587,67 +9676,67 @@ Tunnusta ei näytetä käyttäjälle</source>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="14"/>
         <source>Muokkaa raportin riviä</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit report row</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="27"/>
         <source>Laskenta</source>
-        <translation type="unfinished"></translation>
+        <translation>Calculation</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="33"/>
         <source>Summa</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="43"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="50"/>
         <source>Välisumma</source>
-        <translation type="unfinished"></translation>
+        <translation>Subtotal</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="57"/>
         <source>Näytä tyhjä</source>
-        <translation type="unfinished"></translation>
+        <translation>Show empty</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="64"/>
         <source>Laske välisummaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Include in subtotal</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="74"/>
         <source>Tiliväli(t)</source>
-        <translation type="unfinished"></translation>
+        <translation>Account range(s)</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="104"/>
         <source>Muoto</source>
-        <translation type="unfinished"></translation>
+        <translation>Format</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="110"/>
         <source>Sisennys</source>
-        <translation type="unfinished"></translation>
+        <translation>Indentation</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="127"/>
         <source>Väli ennen</source>
-        <translation type="unfinished"></translation>
+        <translation>Space before</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="134"/>
         <source>Lihavointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Bold</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raportinmuokkausdialogi.ui" line="144"/>
         <source>Erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Specification</translation>
     </message>
 </context>
 <context>
@@ -9655,78 +9744,79 @@ Tunnusta ei näytetä käyttäjälle</source>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="24"/>
         <source>Kausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Period</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="37"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="50"/>
         <source>Vastaanottajat</source>
-        <translation type="unfinished"></translation>
+        <translation>Recipients</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="63"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="93"/>
         <source>Raporttikooste-toiminto on testikäytössä. 
 Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
-        <translation type="unfinished"></translation>
+        <translation>The report summary function is in test use. 
+In future versions, the function will change significantly.</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="111"/>
         <source>Vapaamuotoinen saateviesti</source>
-        <translation type="unfinished"></translation>
+        <translation>Free-form cover message</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="133"/>
         <source>Esikatsele</source>
-        <translation type="unfinished"></translation>
+        <translation>Preview</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.ui" line="144"/>
         <source>Lähetä</source>
-        <translation type="unfinished"></translation>
+        <translation>Send</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.cpp" line="171"/>
         <source>Raportin lähettäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to send the report</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.cpp" line="171"/>
         <source>Raporttia ei voitu lähettää osoitteeseen %1</source>
-        <translation type="unfinished"></translation>
+        <translation>The report could not be sent to address %1</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.cpp" line="173"/>
         <source>Raportin tallentaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save the report</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.cpp" line="173"/>
         <source>Raportin tallentaminen kirjanpitoon epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save the report to accounting</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.cpp" line="175"/>
         <source>Raportti lähetetty %1 vastaanottajalle</source>
-        <translation type="unfinished"></translation>
+        <translation>Report sent to %1 recipient(s)</translation>
     </message>
     <message>
         <location filename="../raportti/kooste/raporttikoostajawidget.cpp" line="177"/>
         <source>Raportti tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Report saved</translation>
     </message>
 </context>
 <context>
@@ -9734,38 +9824,38 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="32"/>
         <source>Teksti</source>
-        <translation type="unfinished"></translation>
+        <translation>Text</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="33"/>
         <source>Tyyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="34"/>
         <source>Kaava</source>
-        <translation type="unfinished"></translation>
+        <translation>Formula</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="76"/>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="82"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="78"/>
         <source>Eritelty summa</source>
-        <translation type="unfinished"></translation>
+        <translation>Itemized sum</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="80"/>
         <source>Välisumma</source>
-        <translation type="unfinished"></translation>
+        <translation>Subtotal</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttimuokkausmodel.cpp" line="84"/>
         <source>Summa</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount</translation>
     </message>
 </context>
 <context>
@@ -9773,17 +9863,17 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttinimikedialogi.ui" line="14"/>
         <source>Raportin nimikkeet</source>
-        <translation type="unfinished"></translation>
+        <translation>Report items</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttinimikedialogi.ui" line="24"/>
         <source>Raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>Report</translation>
     </message>
     <message>
         <location filename="../maaritys/raportinmuokkaus/raporttinimikedialogi.ui" line="38"/>
         <source>Muoto</source>
-        <translation type="unfinished"></translation>
+        <translation>Format</translation>
     </message>
 </context>
 <context>
@@ -9791,92 +9881,92 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="67"/>
         <source>Päiväkirja</source>
-        <translation type="unfinished"></translation>
+        <translation>Journal</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="68"/>
         <source>Pääkirja</source>
-        <translation type="unfinished"></translation>
+        <translation>General ledger</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="69"/>
         <source>Tositeluettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Document list</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="71"/>
         <source>Tase</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="72"/>
         <source>Tuloslaskelma</source>
-        <translation type="unfinished"></translation>
+        <translation>Income statement</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="75"/>
         <source>Tase kuukausittain</source>
-        <translation type="unfinished"></translation>
+        <translation>Monthly balance sheet</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="76"/>
         <source>Tuloslaskelma kuukausittain</source>
-        <translation type="unfinished"></translation>
+        <translation>Monthly income statement</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="80"/>
         <source>Kustannuspaikat</source>
-        <translation type="unfinished"></translation>
+        <translation>Cost centers</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="82"/>
         <source>Projektit</source>
-        <translation type="unfinished"></translation>
+        <translation>Projects</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="106"/>
         <source>Budjettivertailu</source>
-        <translation type="unfinished"></translation>
+        <translation>Budget comparison</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="108"/>
         <source>Tase-erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet specification</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="110"/>
         <source>Tililuettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="112"/>
         <source>Laskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoices</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="113"/>
         <source>Myynti</source>
-        <translation type="unfinished"></translation>
+        <translation>Sales</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="116"/>
         <source>Arvonlisäveron erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT breakdown</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="118"/>
         <source>Tositekooste</source>
-        <translation type="unfinished"></translation>
+        <translation>Document summary</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="122"/>
         <source>Lähetä raporttikooste</source>
-        <translation type="unfinished"></translation>
+        <translation>Send report summary</translation>
     </message>
     <message>
         <location filename="../raportti/raporttisivu.cpp" line="123"/>
         <source>Lähetetyt raporttikoosteet</source>
-        <translation type="unfinished"></translation>
+        <translation>Sent report summaries</translation>
     </message>
 </context>
 <context>
@@ -9884,17 +9974,17 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../raportti/raporttiwidget.cpp" line="60"/>
         <source>Esikatsele</source>
-        <translation type="unfinished"></translation>
+        <translation>Preview</translation>
     </message>
     <message>
         <location filename="../raportti/raporttiwidget.cpp" line="88"/>
         <source>Ei raportoitavaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Nothing to report</translation>
     </message>
     <message>
         <location filename="../raportti/raporttiwidget.cpp" line="89"/>
         <source>Tekemilläsi valinnoilla muodostuu tyhjä raportti</source>
-        <translation type="unfinished"></translation>
+        <translation>Your selections result in an empty report</translation>
     </message>
 </context>
 <context>
@@ -9903,62 +9993,62 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="14"/>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="28"/>
         <source>Tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="41"/>
         <source>Otsikot ensimmäisellä rivillä</source>
-        <translation type="unfinished"></translation>
+        <translation>Headers on the first row</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="53"/>
         <source>Ryhmät</source>
-        <translation type="unfinished"></translation>
+        <translation>Groups</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="67"/>
         <source>Oletukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Defaults</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="73"/>
         <source>Maa</source>
-        <translation type="unfinished"></translation>
+        <translation>Country</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="86"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="99"/>
         <source>Ensisijainen laskutustapa</source>
-        <translation type="unfinished"></translation>
+        <translation>Primary billing method</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.ui" line="128"/>
         <source>Toissijainen laskutustapa</source>
-        <translation type="unfinished"></translation>
+        <translation>Secondary billing method</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.cpp" line="68"/>
         <source>Tulostus</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.cpp" line="69"/>
         <source>Postitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Mailing</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.cpp" line="70"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontidlg.cpp" line="71"/>
         <source>Verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice</translation>
     </message>
 </context>
 <context>
@@ -9966,77 +10056,77 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="34"/>
         <source>Sarake</source>
-        <translation type="unfinished"></translation>
+        <translation>Column</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="36"/>
         <source>Tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="102"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="103"/>
         <source>Lähiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Street address</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="104"/>
         <source>Postinumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Postal code</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="105"/>
         <source>Kaupunki</source>
-        <translation type="unfinished"></translation>
+        <translation>City</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="106"/>
         <source>Postiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Postal address</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="107"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="108"/>
         <source>Puhelin</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="109"/>
         <source>Y-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="110"/>
         <source>Verkkolaskuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice address</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="111"/>
         <source>Verkkolaskuvälittäjä</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice operator</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="112"/>
         <source>Maa</source>
-        <translation type="unfinished"></translation>
+        <translation>Country</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="113"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterituontimodel.cpp" line="114"/>
         <source>Lisätieto</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional information</translation>
     </message>
 </context>
 <context>
@@ -10044,17 +10134,17 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../rekisteri/rekisterinvienti.cpp" line="102"/>
         <source>%1 yhteystietoa viety</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 contacts exported</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterinvienti.cpp" line="104"/>
         <source>Rekisterin vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>Export register</translation>
     </message>
     <message>
         <location filename="../rekisteri/rekisterinvienti.cpp" line="105"/>
         <source>Tiedostoon %1 kirjoittaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to write to file %1</translation>
     </message>
 </context>
 <context>
@@ -10062,62 +10152,62 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="95"/>
         <source>Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="99"/>
         <source>Päivitä luettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Update list</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="178"/>
         <source>Käänteinen arvonlisävero</source>
-        <translation type="unfinished"></translation>
+        <translation>Reverse charge VAT</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="179"/>
         <source>Rakennuspalveluiden myynti voidaan laskuttaa vain yritykseltä, jolla on ALV-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Construction services can only be invoiced from a company with a VAT number</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="186"/>
         <source>Yhteisömyynti</source>
-        <translation type="unfinished"></translation>
+        <translation>Intra-community supply</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="187"/>
         <source>Yhteisömyynti voidaan laskuttaa vain toiseen EU-maahan</source>
-        <translation type="unfinished"></translation>
+        <translation>Intra-community supply can only be invoiced to another EU country</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="193"/>
         <source>Arvonlisäveroilmoitus annettu</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT return submitted</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="194"/>
         <source>Laskun päivämäärältä on jo annettu arvonlisäveroilmoitus</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT return has already been submitted for the invoice date</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="299"/>
         <source>Verottomat rivit</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax-free lines</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="300"/>
         <source>Verolliset rivit</source>
-        <translation type="unfinished"></translation>
+        <translation>Taxable lines</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="301"/>
         <source>Pitkät rivit</source>
-        <translation type="unfinished"></translation>
+        <translation>Long lines</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/rivillinenlaskudialogi.cpp" line="326"/>
         <source>%1 + ALV %2 = &lt;b&gt;%3&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 + VAT %2 = &lt;b&gt;%3&lt;/b&gt;</translation>
     </message>
 </context>
 <context>
@@ -10126,22 +10216,22 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
         <location filename="../laskutus/laskudlg/ryhmalaskudialogi.cpp" line="34"/>
         <location filename="../laskutus/laskudlg/ryhmalaskudialogi.cpp" line="63"/>
         <source>Ryhmälasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Group invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/ryhmalaskudialogi.cpp" line="39"/>
         <source>Laskutettavat</source>
-        <translation type="unfinished"></translation>
+        <translation>Billable</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/ryhmalaskudialogi.cpp" line="64"/>
         <source>Lisää ensin laskun saajat Laskutettavat-välilehdelle.</source>
-        <translation type="unfinished"></translation>
+        <translation>First add invoice recipients to the Billable tab.</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/ryhmalaskudialogi.cpp" line="77"/>
         <source>Laskut tallennettu Lähtevät-kansioon</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoices saved to Outgoing folder</translation>
     </message>
 </context>
 <context>
@@ -10149,27 +10239,27 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../laskutus/ryhmalasku/ryhmalaskutab.cpp" line="89"/>
         <source>Suodata nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by name</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/ryhmalaskutab.cpp" line="114"/>
         <source>Uusi asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>New customer</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/ryhmalaskutab.cpp" line="117"/>
         <source>Lisää kaikki</source>
-        <translation type="unfinished"></translation>
+        <translation>Add all</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/ryhmalaskutab.cpp" line="144"/>
         <source>Lähetystapa</source>
-        <translation type="unfinished"></translation>
+        <translation>Delivery method</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/ryhmalaskutab.cpp" line="139"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
@@ -10177,27 +10267,27 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../laskutus/ryhmantuontidlg.ui" line="14"/>
         <source>Laskutettavien tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>Import billables</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmantuontidlg.ui" line="22"/>
         <source>Sarakkeen sisältö</source>
-        <translation type="unfinished"></translation>
+        <translation>Column content</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmantuontidlg.ui" line="44"/>
         <source>Ensimmäisellä rivillä otsikkoja</source>
-        <translation type="unfinished"></translation>
+        <translation>Headers on the first row</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmantuontidlg.ui" line="53"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmantuontidlg.ui" line="60"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
 </context>
 <context>
@@ -10205,12 +10295,12 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
     <message>
         <location filename="../rekisteri/ryhmatmodel.cpp" line="28"/>
         <source>Ryhmät</source>
-        <translation type="unfinished"></translation>
+        <translation>Groups</translation>
     </message>
     <message>
         <location filename="../rekisteri/ryhmatmodel.cpp" line="48"/>
         <source>Kaikki ryhmät</source>
-        <translation type="unfinished"></translation>
+        <translation>All groups</translation>
     </message>
 </context>
 <context>
@@ -10220,17 +10310,17 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
         <location filename="../sqlite/sqlitemodel.cpp" line="196"/>
         <location filename="../sqlite/sqlitemodel.cpp" line="203"/>
         <source>Kirjanpitoa ei voi avata</source>
-        <translation type="unfinished"></translation>
+        <translation>Unable to open accounting</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="164"/>
         <source>Tietokannan avaaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to open database</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="165"/>
         <source>Tietokannan %1 avaaminen epäonnistui tietokantavirheen %2 takia</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to open database %1 due to database error %2</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="190"/>
@@ -10239,56 +10329,63 @@ Tulevissa versioissa toiminto tulee muuttumaan merkittävästi.</source>
 Sulje kaikki Kitsas-ohjelman ikkunat ja yritä uudelleen.
 
 Ellei tämä auta, käynnistä tietokoneesi uudelleen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting file %1 is already in use.
+
+Close all Kitsas program windows and try again.
+
+If this doesn&apos;t help, restart your computer.</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="197"/>
         <source>Kirjanpitotiedosto %1 on todennäköisesti vahingoittunut joko tiedostojärjestelmän virheen tai levyvirheen takia, tai tiedosto ei ole Kitsaan kirjanpitotiedosto.</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting file %1 is likely damaged due to a file system error or disk error, or the file is not a Kitsas accounting file.</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="198"/>
         <source>Ellei tietokoneen uudelleen käynnistäminen auta, ota käyttöön kirjanpitosi varmuuskopio.</source>
-        <translation type="unfinished"></translation>
+        <translation>If restarting your computer doesn&apos;t help, use your accounting backup.</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="204"/>
         <location filename="../sqlite/sqlitemodel.cpp" line="268"/>
         <source>Tiedostoa %1 ei voi avata</source>
-        <translation type="unfinished"></translation>
+        <translation>Cannot open file %1</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="205"/>
         <source>Sql-virhe: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>SQL error: %1</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="216"/>
         <source>Kirjanpitoa %1 ei voi avata</source>
-        <translation type="unfinished"></translation>
+        <translation>Cannot open accounting %1</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="217"/>
         <source>Kirjanpito on luotu uudemmalla Kitsaan versiolla, eikä käytössäsi oleva versio %1 pysty avaamaan sitä.
 
 Voidaksesi avata tiedoston, sinun on asennettava uudempi versio Kitsaasta. Lataa ohjelma osoitteesta https://kitsas.fi</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting was created with a newer version of Kitsas, and your current version %1 cannot open it.
+
+To open the file, you need to install a newer version of Kitsas. Download the program from https://kitsas.fi</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="225"/>
         <source>Kirjanpidon päivittäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Updating accounting</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="226"/>
         <source>Avataksesi kirjanpidon pitää se päivittää yhteensopivaksi nykyisen version kanssa. Päivityksen jälkeen kirjanpitoa ei voi enää avata varhaisemmilla esiversioilla. 
 Päivitetäänkö kirjanpito nyt?</source>
-        <translation type="unfinished"></translation>
+        <translation>To open the accounting, it needs to be updated to be compatible with the current version. After the update, the accounting can no longer be opened with earlier pre-release versions. 
+Do you want to update the accounting now?</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitemodel.cpp" line="269"/>
         <source>Valitsemasi tiedosto ei ole Kitsaan tietokanta, tai tiedosto on vahingoittunut.</source>
-        <translation type="unfinished"></translation>
+        <translation>The file you selected is not a Kitsas database, or the file is corrupted.</translation>
     </message>
 </context>
 <context>
@@ -10297,18 +10394,20 @@ Päivitetäänkö kirjanpito nyt?</source>
         <location filename="../laskutus/toimittaja/sahkopostitoimittaja.cpp" line="134"/>
         <source>Sähköpostipalvelimeen %1 yhdistäminen epäonnistui.
 Tarkista sähköpostien lähettämisen asetukset.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to connect to email server %1.
+Check the email sending settings.</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/sahkopostitoimittaja.cpp" line="141"/>
         <source>Sähköpostipalvelimelle %1 kirjautuminen epäonnistui.
 Tarkista sähköpostien lähettämisen asetukset.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to log in to email server %1.
+Check the email sending settings.</translation>
     </message>
     <message>
         <location filename="../laskutus/toimittaja/sahkopostitoimittaja.cpp" line="150"/>
         <source>Laskujen lähettäminen sähköpostilla epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to send invoices by email.</translation>
     </message>
 </context>
 <context>
@@ -10316,72 +10415,72 @@ Tarkista sähköpostien lähettämisen asetukset.</source>
     <message>
         <location filename="../aloitussivu/salasananvaihto.ui" line="14"/>
         <source>Vaihda salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Change password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.ui" line="22"/>
         <source>Vanha salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Old password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.ui" line="36"/>
         <source>Uusi salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>New password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.ui" line="50"/>
         <source>Uusi salasana uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Repeat new password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.ui" line="66"/>
         <source>Vaadi uusi kirjautuminen kaikilla tietokoneilla</source>
-        <translation type="unfinished"></translation>
+        <translation>Require new login on all computers</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.ui" line="86"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="65"/>
         <source>Kirjoita vanha salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter old password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="67"/>
         <source>Uuden salasanan on oltava vähintään 10 merkkiä pitkä.</source>
-        <translation type="unfinished"></translation>
+        <translation>The new password must be at least 10 characters long.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="71"/>
         <source>Uudessa salasanassa on oltava pieniä ja isoja kirjaimia sekä numeroita.</source>
-        <translation type="unfinished"></translation>
+        <translation>The new password must contain lowercase and uppercase letters, and numbers.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="73"/>
         <source>Salasanat eivät täsmää</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwords do not match</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="83"/>
         <source>Salasanan vaihto epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Password change failed</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="83"/>
         <source>Antamasi nykyinen salasana on väärin.</source>
-        <translation type="unfinished"></translation>
+        <translation>The current password you provided is incorrect.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="88"/>
         <source>Salasana vaihdettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Password changed</translation>
     </message>
     <message>
         <location filename="../aloitussivu/salasananvaihto.cpp" line="88"/>
         <source>Salasanasi on nyt vaihdettu.</source>
-        <translation type="unfinished"></translation>
+        <translation>Your password has now been changed.</translation>
     </message>
 </context>
 <context>
@@ -10389,7 +10488,7 @@ Tarkista sähköpostien lähettämisen asetukset.</source>
     <message>
         <location filename="../saldodock/saldodock.cpp" line="40"/>
         <source>Saldot</source>
-        <translation type="unfinished"></translation>
+        <translation>Balances</translation>
     </message>
 </context>
 <context>
@@ -10397,47 +10496,47 @@ Tarkista sähköpostien lähettämisen asetukset.</source>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="60"/>
         <source>Tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="62"/>
         <source>Pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="64"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="66"/>
         <source>Debet</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="68"/>
         <source>Kredit</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="70"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="72"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="74"/>
         <source>Asiakas/Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/Supplier</translation>
     </message>
     <message>
         <location filename="../selaus/selausmodel.cpp" line="76"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
 </context>
 <context>
@@ -10445,170 +10544,171 @@ Tarkista sähköpostien lähettämisen asetukset.</source>
     <message>
         <location filename="../selaus/selauswg.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="52"/>
         <source>Tämä kuukausi</source>
-        <translation type="unfinished"></translation>
+        <translation>This month</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="66"/>
         <source>Tämä tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>This accounting period</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="90"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="137"/>
         <source>Etsi</source>
-        <translation type="unfinished"></translation>
+        <translation>Search</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="167"/>
         <source>Poista useita tositteita</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete multiple vouchers</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="187"/>
         <source>Päivitä</source>
-        <translation type="unfinished"></translation>
+        <translation>Update</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="240"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.ui" line="251"/>
         <source>Peruuta</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="48"/>
         <source>&amp;Tositteet</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Vouchers</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="49"/>
         <source>&amp;Luonnokset</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Drafts</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="50"/>
         <source>&amp;Viennit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Entries</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="51"/>
         <source>&amp;Huomioitavat</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Notable</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="52"/>
         <source>&amp;Poistetut</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Deleted</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="53"/>
         <location filename="../selaus/selauswg.cpp" line="478"/>
         <source>&amp;Saapuneet</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Received</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="205"/>
         <source>Edellinen kuukausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous month</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="206"/>
         <source>Seuraava kuukausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Next month</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="215"/>
         <source>Edellinen tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous accounting period</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="216"/>
         <source>Seuraava tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Next accounting period</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="285"/>
         <location filename="../selaus/selauswg.cpp" line="290"/>
         <source>Kaikki tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>All accounts</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="295"/>
         <source>Tiliöimättä</source>
-        <translation type="unfinished"></translation>
+        <translation>Unallocated</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="304"/>
         <source>Kaikki tositteet</source>
-        <translation type="unfinished"></translation>
+        <translation>All vouchers</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="345"/>
         <source>Debet %L1	Kredit %L2 
 Loppusaldo %L3	Lkm %L4</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit %L1	Credit %L2 
+Final balance %L3	Count %L4</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="348"/>
         <source>Debet %L1	Kredit %L2	Lkm %L3</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit %L1	Credit %L2	Count %L3</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="361"/>
         <source>Summa %1 	Lkm %L2</source>
-        <translation type="unfinished"></translation>
+        <translation>Sum %1 	Count %L2</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="453"/>
         <source>Avaa uudessa ikkunassa</source>
-        <translation type="unfinished"></translation>
+        <translation>Open in new window</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="619"/>
         <source>Tositteita ei voi poistaa lukitulta tilikaudelta</source>
-        <translation type="unfinished"></translation>
+        <translation>Vouchers cannot be deleted from a locked accounting period</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="627"/>
         <source>Valitse poistettavat tositteet</source>
-        <translation type="unfinished"></translation>
+        <translation>Select vouchers to be deleted</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="629"/>
         <source>Yksi tosite valittu poistettavaksi</source>
-        <translation type="unfinished"></translation>
+        <translation>One voucher selected for deletion</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="631"/>
         <source>%1 tositetta valittu poistettavaksi</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 vouchers selected for deletion</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="641"/>
         <source>Vahvista poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm deletion</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="642"/>
         <source>Haluatko varmasti poistaa valitsemasi %1 tositetta?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the %1 selected vouchers?</translation>
     </message>
     <message>
         <location filename="../selaus/selauswg.cpp" line="642"/>
         <source>Haluatko varmasti poistaa valitsemasi tositteen?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the selected voucher?</translation>
     </message>
 </context>
 <context>
@@ -10616,37 +10716,37 @@ Loppusaldo %L3	Lkm %L4</source>
     <message>
         <location filename="../kirjaus/siirry.ui" line="17"/>
         <source>Siirry tositteeseen</source>
-        <translation type="unfinished"></translation>
+        <translation>Go to voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/siirry.ui" line="29"/>
         <source>Tositelaji</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher type</translation>
     </message>
     <message>
         <location filename="../kirjaus/siirry.ui" line="36"/>
         <source>Numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Number</translation>
     </message>
     <message>
         <location filename="../kirjaus/siirry.ui" line="43"/>
         <source>Tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period</translation>
     </message>
     <message>
         <location filename="../kirjaus/siirry.ui" line="56"/>
         <source>/</source>
-        <translation type="unfinished"></translation>
+        <translation>/</translation>
     </message>
     <message>
         <location filename="../kirjaus/siirry.ui" line="99"/>
         <source>Siirry</source>
-        <translation type="unfinished"></translation>
+        <translation>Go</translation>
     </message>
     <message>
         <location filename="../kirjaus/siirry.ui" line="113"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
 </context>
 <context>
@@ -10654,60 +10754,60 @@ Loppusaldo %L3	Lkm %L4</source>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="22"/>
         <source>Kredit (an)</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="31"/>
         <source>Tililtä</source>
-        <translation type="unfinished"></translation>
+        <translation>From account</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="44"/>
         <location filename="../apuri/siirtoapuri.ui" line="153"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="57"/>
         <location filename="../apuri/siirtoapuri.ui" line="166"/>
         <source>Tase-erä</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet item</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="70"/>
         <location filename="../apuri/siirtoapuri.ui" line="179"/>
         <source>Merkkaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Marking</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="100"/>
         <source>Euroa</source>
-        <translation type="unfinished"></translation>
+        <translation>Euros</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="113"/>
         <source>Asiakas/toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/supplier</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="131"/>
         <source>Debet (per)</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="140"/>
         <source>Tilille</source>
-        <translation type="unfinished"></translation>
+        <translation>To account</translation>
     </message>
     <message>
         <location filename="../apuri/siirtoapuri.ui" line="222"/>
         <source>&amp;Laskun maksu</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Invoice payment</translation>
     </message>
 </context>
 <context>
@@ -10715,18 +10815,18 @@ Loppusaldo %L3	Lkm %L4</source>
     <message>
         <location filename="../uusikirjanpito/sijaintisivu.cpp" line="28"/>
         <source>Kirjanpidon sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting location</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/sijaintisivu.cpp" line="49"/>
         <source>Valitse sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Select location</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/sijaintisivu.cpp" line="56"/>
         <location filename="../uusikirjanpito/sijaintisivu.cpp" line="103"/>
         <source>Hakemisto ei voi kelpaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Directory cannot be valid</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/sijaintisivu.cpp" line="56"/>
@@ -10734,17 +10834,19 @@ Loppusaldo %L3	Lkm %L4</source>
         <source>Valitsemaasi hakemistoon ei voida luoda uutta tiedostoa. Sinulla ei ehkä ole kirjoitusoikeuksia tähän hakemistoon. 
 
 Ole hyvä ja valitse toinen hakemisto.</source>
-        <translation type="unfinished"></translation>
+        <translation>A new file cannot be created in the directory you selected. You may not have write permissions for this directory. 
+
+Please choose another directory.</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/sijaintisivu.cpp" line="110"/>
         <source>Tiedosto on jo olemassa</source>
-        <translation type="unfinished"></translation>
+        <translation>The file already exists</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/sijaintisivu.cpp" line="110"/>
         <source>Valitsemasi niminen tiedosto on jo olemassa.</source>
-        <translation type="unfinished"></translation>
+        <translation>A file with the name you selected already exists.</translation>
     </message>
 </context>
 <context>
@@ -10752,32 +10854,32 @@ Ole hyvä ja valitse toinen hakemisto.</source>
     <message>
         <location filename="../sqlite/sqlitealustaja.cpp" line="51"/>
         <source>Alustetaan kirjanpitoa...</source>
-        <translation type="unfinished"></translation>
+        <translation>Initializing accounting...</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitealustaja.cpp" line="51"/>
         <source>Peruuta</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitealustaja.cpp" line="70"/>
         <source>Kirjanpidon %1 luominen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create accounting %1</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitealustaja.cpp" line="70"/>
         <source>Tietokannan luominen epäonnistui seuraavan virheen takia: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create database due to the following error: %1</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitealustaja.cpp" line="96"/>
         <source>Kirjanpidon luominen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create accounting</translation>
     </message>
     <message>
         <location filename="../sqlite/sqlitealustaja.cpp" line="96"/>
         <source>Virhe tietokantaa luotaessa: %1 (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Error creating database: %1 (%2)</translation>
     </message>
 </context>
 <context>
@@ -10785,40 +10887,43 @@ Ole hyvä ja valitse toinen hakemisto.</source>
     <message>
         <location filename="../kirjaus/tallennettuwidget.ui" line="14"/>
         <source>Tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Saved</translation>
     </message>
     <message>
         <location filename="../kirjaus/tallennettuwidget.ui" line="110"/>
         <source>Tosite tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher saved</translation>
     </message>
     <message>
         <location filename="../kirjaus/tallennettuwidget.ui" line="80"/>
         <source>15 </source>
-        <translation type="unfinished"></translation>
+        <translation>15 </translation>
     </message>
     <message>
         <location filename="../kirjaus/tallennettuwidget.ui" line="59"/>
         <source>Tosite tallennettu tunnisteella  </source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher saved with identifier  </translation>
     </message>
     <message>
         <location filename="../kirjaus/tallennettuwidget.ui" line="95"/>
         <source>/ 19</source>
-        <translation type="unfinished"></translation>
+        <translation>/ 19</translation>
     </message>
     <message>
         <location filename="../kirjaus/tallennettuwidget.cpp" line="60"/>
         <source>Tosite tallennettu 
 mallipohjana
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher saved 
+as a template
+</translation>
     </message>
     <message>
         <location filename="../kirjaus/tallennettuwidget.cpp" line="62"/>
         <source>Tosite tallennettu tilassa
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher in saved status
+</translation>
     </message>
 </context>
 <context>
@@ -10826,7 +10931,7 @@ mallipohjana
     <message>
         <location filename="../maaritys/tallentavamaarityswidget.cpp" line="285"/>
         <source>Asetukset tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings saved</translation>
     </message>
 </context>
 <context>
@@ -10834,27 +10939,27 @@ mallipohjana
     <message>
         <location filename="../raportti/tasetulosraportti.cpp" line="46"/>
         <source>Kustannuspaikalla</source>
-        <translation type="unfinished"></translation>
+        <translation>At cost center</translation>
     </message>
     <message>
         <location filename="../raportti/tasetulosraportti.cpp" line="58"/>
         <source>Toteutunut</source>
-        <translation type="unfinished"></translation>
+        <translation>Realized</translation>
     </message>
     <message>
         <location filename="../raportti/tasetulosraportti.cpp" line="58"/>
         <source>Budjetti</source>
-        <translation type="unfinished"></translation>
+        <translation>Budget</translation>
     </message>
     <message>
         <location filename="../raportti/tasetulosraportti.cpp" line="58"/>
         <source>Budjettiero €</source>
-        <translation type="unfinished"></translation>
+        <translation>Budget difference €</translation>
     </message>
     <message>
         <location filename="../raportti/tasetulosraportti.cpp" line="58"/>
         <source>Toteutunut %</source>
-        <translation type="unfinished"></translation>
+        <translation>Realized %</translation>
     </message>
 </context>
 <context>
@@ -10862,12 +10967,12 @@ mallipohjana
     <message>
         <location filename="../laskutus/laskudlg/tavallinenlaskudialogi.cpp" line="251"/>
         <source>Ennakkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Advance invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/tavallinenlaskudialogi.cpp" line="252"/>
         <source>Ennakkolasku voidaan laatia vain asiakasrekisterissä olevalle asiakkaalle. Lisää ensin asiakas rekisteriin</source>
-        <translation type="unfinished"></translation>
+        <translation>An advance invoice can only be created for a customer in the customer register. First add the customer to the register</translation>
     </message>
 </context>
 <context>
@@ -10875,13 +10980,14 @@ mallipohjana
     <message>
         <location filename="../aloitussivu/tervetulodialogi.cpp" line="64"/>
         <source>Versio %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Version %1</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetulodialogi.cpp" line="104"/>
         <source>Comment=Avoimen lähdekoodin kirjanpitäjä
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Comment=Open source accountant
+</translation>
     </message>
 </context>
 <context>
@@ -10889,52 +10995,52 @@ mallipohjana
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="14"/>
         <source>Tervetuloa!</source>
-        <translation type="unfinished"></translation>
+        <translation>Welcome!</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="40"/>
         <source>Versio</source>
-        <translation type="unfinished"></translation>
+        <translation>Version</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="47"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;© Arto Hyvättinen ja Kitsas Oy 2017 - 2024&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;© Arto Hyvättinen and Kitsas Oy 2017 - 2024&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="54"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kitsas-ohjelmaan ei sisälly minkäänlaista takuuta ohjelman toimivuudesta tai soveltuvuudesta. Ohjelmaa on testattu, mutta siinä voi silti olla virheitä ja ohjelman käyttäjä ottaa vastuun ohjelman mahdollisesti aiheuttamista vahigoista.&lt;/p&gt;&lt;p&gt;Ohjelmaa saa käyttää ja kopioida maksutta &lt;a href=&quot;https://kitsas.fi/docs/lisenssi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;GNU General Public License 3&lt;/span&gt;&lt;/a&gt;:n ehtojen mukaisesti.&lt;/p&gt;&lt;p&gt;Ohjelman käynnistyessä ohjelman päivitykset tarkastetaan verkosta, ja samalla tallennetaan tilastoitavaksi anonyymi tieto tietokoneen käyttöjärjestelmästä, ohjelman versiosta ja käytetystä tilikartasta.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The Kitsas program does not include any warranty for the functionality or suitability of the program. The program has been tested, but it may still contain errors and the user of the program takes responsibility for any damages possibly caused by the program.&lt;/p&gt;&lt;p&gt;The program can be used and copied free of charge under the terms of the &lt;a href=&quot;https://kitsas.fi/docs/lisenssi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;GNU General Public License 3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;When the program starts, program updates are checked online, and at the same time anonymous information about the computer&apos;s operating system, program version, and the chart of accounts used is saved for statistical purposes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="67"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="73"/>
         <source>suomi</source>
-        <translation type="unfinished"></translation>
+        <translation>Finnish</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="84"/>
         <source>ruotsi</source>
-        <translation type="unfinished"></translation>
+        <translation>Swedish</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="98"/>
         <source>Ymmärrän, että ohjelmalla ei ole takuuta.</source>
-        <translation type="unfinished"></translation>
+        <translation>I understand that the program has no warranty.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="123"/>
         <source>Lisää Kitsas aloitusvalikkoon</source>
-        <translation type="unfinished"></translation>
+        <translation>Add Kitsas to the start menu</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tervetuloa.ui" line="149"/>
         <source>Jatka</source>
-        <translation type="unfinished"></translation>
+        <translation>Continue</translation>
     </message>
 </context>
 <context>
@@ -10942,29 +11048,29 @@ mallipohjana
     <message>
         <location filename="../uusikirjanpito/tiedotsivu.cpp" line="39"/>
         <source>Organisaation tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Organization information</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tiedotsivu.cpp" line="97"/>
         <location filename="../uusikirjanpito/tiedotsivu.cpp" line="101"/>
         <location filename="../uusikirjanpito/tiedotsivu.cpp" line="106"/>
         <source>Perustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic information</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tiedotsivu.cpp" line="97"/>
         <source>Y-tunnuksen muoto virheellinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID format is incorrect</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tiedotsivu.cpp" line="101"/>
         <source>Tilinumeron muoto virheellinen. Tilinumero on syötettävä IBAN-muodossa</source>
-        <translation type="unfinished"></translation>
+        <translation>Account number format is incorrect. The account number must be entered in IBAN format</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tiedotsivu.cpp" line="106"/>
         <source>BIC-numeron muoto virheellinen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid BIC number format.</translation>
     </message>
 </context>
 <context>
@@ -10972,22 +11078,22 @@ mallipohjana
     <message>
         <location filename="../tilaus/tilausvahvistus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvahvistus.ui" line="20"/>
         <source>Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvahvistus.ui" line="39"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ole hyvä ja lue &lt;a href=&quot;https://kitsas.fi/ehdot/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;käyttöehdot&lt;/span&gt;&lt;/a&gt; ennen tilauksen vahvistamista&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Please read the &lt;a href=&quot;https://kitsas.fi/ehdot/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;terms of use&lt;/span&gt;&lt;/a&gt; before confirming your subscription&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvahvistus.ui" line="52"/>
         <source>Hyväksyn käyttöehdot</source>
-        <translation type="unfinished"></translation>
+        <translation>I accept the terms of use</translation>
     </message>
 </context>
 <context>
@@ -10995,52 +11101,52 @@ mallipohjana
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="32"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maksullisella tilauksella pääset tallentamaan kirjanpitosi varmuuskopioituun kotimaiseen pilveen, ja saat käyttöösi monia lisäominaisuuksia.&lt;/p&gt;&lt;p&gt;Tutustu tarkemmin tarjolla oleviin ominaisuuksiin ja paketteihin osoitteessa &lt;a href=&quot;https://kitsas.fi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0078d4;&quot;&gt;kitsas.fi&lt;/span&gt;&lt;/a&gt; ja valitse sinulle parhaiten sopiva palvelu&lt;/p&gt;&lt;p&gt;Hinnat sisältävät arvonlisäveron&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;With a paid subscription, you can save your accounting to a backed-up domestic cloud and get access to many additional features.&lt;/p&gt;&lt;p&gt;Learn more about the available features and packages at &lt;a href=&quot;https://kitsas.fi&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0078d4;&quot;&gt;kitsas.fi&lt;/span&gt;&lt;/a&gt; and choose the service that best suits you&lt;/p&gt;&lt;p&gt;Prices include VAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="64"/>
         <source>Lisäkirjanpidot pilvessä</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional accounting in the cloud</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="70"/>
         <source>Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="79"/>
         <source>Tilaan lisäksi pilvitilaa</source>
-        <translation type="unfinished"></translation>
+        <translation>I also order cloud space</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="89"/>
         <source>kirjanpidolle hintaan </source>
-        <translation type="unfinished"></translation>
+        <translation>for accounting at the price of </translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="96"/>
         <source>40 €  / kpl</source>
-        <translation type="unfinished"></translation>
+        <translation>40 € / piece</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="108"/>
         <source>Laskutusväli</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing interval</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="114"/>
         <source>Vuosi</source>
-        <translation type="unfinished"></translation>
+        <translation>Year</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalinta.ui" line="121"/>
         <source>Puoli vuotta</source>
-        <translation type="unfinished"></translation>
+        <translation>Half a year</translation>
     </message>
 </context>
 <context>
@@ -11048,110 +11154,120 @@ mallipohjana
     <message>
         <location filename="../tilaus/tilausvalintasivu.cpp" line="83"/>
         <source>Tilataksesi pilvitilaa useammalle kirjanpidolle valitse toinen paketti</source>
-        <translation type="unfinished"></translation>
+        <translation>To order cloud space for multiple accounting, choose another package</translation>
+    </message>
+    <message>
+        <location filename="../tilaus/tilausvalintasivu.cpp" line="87"/>
+        <source>Lisäkirjanpidoista laskutetaan jälkikäteen %1/kuukausi</source>
+        <translation>Additional accounting will be billed afterwards at %1/month</translation>
+    </message>
+    <message>
+        <location filename="../tilaus/tilausvalintasivu.cpp" line="99"/>
+        <source>%L1 € / kpl</source>
+        <translation>%L1 € / piece</translation>
+    </message>
+    <message>
+        <location filename="../tilaus/tilausvalintasivu.cpp" line="102"/>
+        <source>Lisähintaa voidaan periä, jos kirjanpidon koko ylittää %L1 Gt.</source>
+        <translation>Additional charges may apply if the accounting size exceeds %L1 GB.</translation>
+    </message>
+    <message>
+        <location filename="../tilaus/tilausvalintasivu.cpp" line="106"/>
+        <source>Vaihtaessasi isompaan tilaukseen hyvitetään ensimmäiseltä laskulta %L1 € nykyisestä tilauksestasi.</source>
+        <translation>When upgrading to a larger subscription, %L1 € from your current subscription will be credited on your first invoice.</translation>
+    </message>
+    <message>
+        <location filename="../tilaus/tilausvalintasivu.cpp" line="90"/>
+        <source>Pakettihintaan kuuluu yhden kirjanpidon tallentaminen pilveen</source>
+        <translation>The package price includes cloud storage for one accounting</translation>
+    </message>
+    <message>
+        <location filename="../tilaus/tilausvalintasivu.cpp" line="42"/>
+        <source>Valitse tilaus</source>
+        <translation>Select subscription</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalintasivu.cpp" line="86"/>
         <source>Pakettihintaan kuuluu %1 kirjanpidon tallentaminen pilveen.
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tilaus/tilausvalintasivu.cpp" line="87"/>
-        <source>Lisäkirjanpidoista laskutetaan jälkikäteen %1/kuukausi</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tilaus/tilausvalintasivu.cpp" line="99"/>
-        <source>%L1 € / kpl</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tilaus/tilausvalintasivu.cpp" line="102"/>
-        <source>Lisähintaa voidaan periä, jos kirjanpidon koko ylittää %L1 Gt.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tilaus/tilausvalintasivu.cpp" line="106"/>
-        <source>Vaihtaessasi isompaan tilaukseen hyvitetään ensimmäiseltä laskulta %L1 € nykyisestä tilauksestasi.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tilaus/tilausvalintasivu.cpp" line="90"/>
-        <source>Pakettihintaan kuuluu yhden kirjanpidon tallentaminen pilveen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../tilaus/tilausvalintasivu.cpp" line="42"/>
-        <source>Valitse tilaus</source>
-        <translation type="unfinished"></translation>
+        <translation>The package price includes cloud storage for %1 accounting(s).
+</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausvalintasivu.cpp" line="91"/>
         <source>Pakettihintaan kuuluu %1 kirjanpidon tallentaminen pilveen</source>
-        <translation type="unfinished"></translation>
+        <translation>The package price includes cloud storage for %1 accounting(s)</translation>
     </message>
 </context>
 <context>
     <name>TilausWizard</name>
     <message>
-        <location filename="../tilaus/tilauswizard.cpp" line="70"/>
-        <source>Tilaamasi paketti: %1 
-
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../tilaus/tilauswizard.cpp" line="94"/>
         <source>laskutettuna puolivuosittain
 </source>
-        <translation type="unfinished"></translation>
+        <translation>billed semi-annually
+</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="96"/>
         <source>laskutettuna vuosittain
 </source>
-        <translation type="unfinished"></translation>
+        <translation>billed annually
+</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="79"/>
         <source>Paketin hintaan sisältyy %1 kirjanpitoa.</source>
-        <translation type="unfinished"></translation>
+        <translation>The package price includes %1 accounting(s).</translation>
+    </message>
+    <message>
+        <location filename="../tilaus/tilauswizard.cpp" line="70"/>
+        <source>Tilaamasi paketti: %1 
+
+</source>
+        <translation>Your selected package: %1 
+
+</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="81"/>
         <source>Lisäkirjanpidoista laskutetaan jälkikäteen %1/kk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional accountings will be billed afterwards at %1/month.</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="83"/>
         <source>
 Voit tallentaa pilveen enintään %1 kirjanpitoa.</source>
-        <translation type="unfinished"></translation>
+        <translation>
+You can store up to %1 accountings in the cloud.</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="92"/>
         <source>
 
 Hinta %L1 € </source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+Price %L1 € </translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="103"/>
         <source>Ensimmäiseltä laskulta vähennetään nykyistä tilaustasi %L1€, jolloin maksettavaa jää %L2€.</source>
-        <translation type="unfinished"></translation>
+        <translation>Your current subscription of %L1€ will be deducted from the first invoice, leaving %L2€ to be paid.</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="110"/>
         <source>
 Lasku toimitetaan sähköpostilla osoitteeseen %1</source>
-        <translation type="unfinished"></translation>
+        <translation>
+The invoice will be sent by email to %1</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="113"/>
         <source>
 Lasku toimitetaan verkkolaskuna</source>
-        <translation type="unfinished"></translation>
+        <translation>
+The invoice will be sent as an e-invoice</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="116"/>
@@ -11159,55 +11275,60 @@ Lasku toimitetaan verkkolaskuna</source>
 
 Laskun saajaksi merkitään
 </source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+The recipient of the invoice is marked as
+</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="135"/>
         <location filename="../tilaus/tilauswizard.cpp" line="237"/>
         <source>Verkkovirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Network error</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="135"/>
         <source>Tilaustietojen hakeminen palvelimelta epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to retrieve subscription information from the server</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="149"/>
         <source>VIP-asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>VIP customer</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="150"/>
         <source>Sinulla on käytössäsi VIP-tuote, joka ei ole yleisesti myynnissä. 
 
 Muutokset tehdään asiakaspalvelun kautta.</source>
-        <translation type="unfinished"></translation>
+        <translation>You are using a VIP product that is not generally available for sale. 
+
+Changes are made through customer service.</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="237"/>
         <source>Tilauksen lähettäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to send subscription</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="246"/>
         <source>Kitsas</source>
-        <translation type="unfinished"></translation>
+        <translation>Narrow</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="246"/>
         <source>Tilauksesi on päivitetty</source>
-        <translation type="unfinished"></translation>
+        <translation>Your order has been updated</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="257"/>
         <source>Laskutustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing information</translation>
     </message>
     <message>
         <location filename="../tilaus/tilauswizard.cpp" line="340"/>
         <source>Vahvista tilaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm order</translation>
     </message>
 </context>
 <context>
@@ -11215,78 +11336,78 @@ Muutokset tehdään asiakaspalvelun kautta.</source>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lasku toimitetaan kahden viikon kuluessa tilauksesi alkamisesta.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Jos laskun maksaa yritys tai yhdistys, merkitse tämän tiedot laskun saajaksi.&lt;/b&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The invoice will be delivered within two weeks of the start of your order.&lt;/p&gt;&lt;p&gt;&lt;b&gt;If the invoice is paid by a company or association, mark their details as the invoice recipient.&lt;/b&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="30"/>
         <source>Laskutustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing information</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="36"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="43"/>
         <source>Verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="52"/>
         <source>Laskutussähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing email</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="65"/>
         <source>Verkkolaskuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice address</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="75"/>
         <source>Operaattoritunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Operator ID</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="90"/>
         <source>Laskun saaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice recipient</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="96"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="109"/>
         <source>Lähiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Street address</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="132"/>
         <source>Postinumero
 ja kaupunki</source>
-        <translation type="unfinished"></translation>
+        <translation>Postal code and city</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="150"/>
         <source>Asiakkaan viite</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer reference</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="163"/>
         <source>Y-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID</translation>
     </message>
     <message>
         <location filename="../tilaus/tilausyhteys.ui" line="173"/>
         <source>Puhelinnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number</translation>
     </message>
 </context>
 <context>
@@ -11294,43 +11415,44 @@ ja kaupunki</source>
     <message>
         <location filename="../db/tilimodel.cpp" line="67"/>
         <source>Numero ja nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Number and name</translation>
     </message>
     <message>
         <location filename="../db/tilimodel.cpp" line="69"/>
         <source>Numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Number</translation>
     </message>
     <message>
         <location filename="../db/tilimodel.cpp" line="71"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../db/tilimodel.cpp" line="73"/>
         <source>Tilityyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Account type</translation>
     </message>
     <message>
         <location filename="../db/tilimodel.cpp" line="75"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../db/tilimodel.cpp" line="77"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <location filename="../db/tilimodel.cpp" line="237"/>
         <source>Virhe tallentamisessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Error in saving</translation>
     </message>
     <message>
         <location filename="../db/tilimodel.cpp" line="237"/>
         <source>Tilin tallentaminen epäonnistui.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save the account.
+%1</translation>
     </message>
 </context>
 <context>
@@ -11338,17 +11460,17 @@ ja kaupunki</source>
     <message>
         <location filename="../tuonti/tilimuuntodlg.ui" line="14"/>
         <source>Tilinumeroiden muunto</source>
-        <translation type="unfinished"></translation>
+        <translation>Account number conversion</translation>
     </message>
     <message>
         <location filename="../tuonti/tilimuuntodlg.ui" line="25"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../tuonti/tilimuuntodlg.ui" line="32"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
 </context>
 <context>
@@ -11356,22 +11478,22 @@ ja kaupunki</source>
     <message>
         <location filename="../tuonti/tilimuuntomodel.cpp" line="104"/>
         <source>Numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Number</translation>
     </message>
     <message>
         <location filename="../tuonti/tilimuuntomodel.cpp" line="106"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../tuonti/tilimuuntomodel.cpp" line="108"/>
         <source>Kirjataan tilille</source>
-        <translation type="unfinished"></translation>
+        <translation>Posted to account</translation>
     </message>
     <message>
         <location filename="../tuonti/tilimuuntomodel.cpp" line="110"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
 </context>
 <context>
@@ -11379,77 +11501,77 @@ ja kaupunki</source>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="28"/>
         <source>Tililuettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of Accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="48"/>
         <source>Näytä kaikki tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Show all accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="68"/>
         <source>Näytä käytettävissä olevat tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Show available accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="85"/>
         <source>Näytä vain suosikkitilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Show only favorite accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="102"/>
         <source>Siirry tiliin nro</source>
-        <translation type="unfinished"></translation>
+        <translation>Go to account number</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="109"/>
         <source>Suodata numerolla tai nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by number or name</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="142"/>
         <source>Uusi &amp;otsikko...</source>
-        <translation type="unfinished"></translation>
+        <translation>New &amp;header...</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="149"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="159"/>
         <source>Uusi &amp;tili..</source>
-        <translation type="unfinished"></translation>
+        <translation>New &amp;account..</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="173"/>
         <source>&amp;Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Edit</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="197"/>
         <source>P&amp;iilota</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Hide</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="214"/>
         <source>&amp;Normaali</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Normal</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="231"/>
         <source>Nä&amp;ytä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Show</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttamuokkaus.ui" line="245"/>
         <source>&amp;Suosikki</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Favorite</translation>
     </message>
 </context>
 <context>
@@ -11457,73 +11579,73 @@ ja kaupunki</source>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="37"/>
         <source>Tilikartta</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="44"/>
         <source>kartta</source>
-        <translation type="unfinished"></translation>
+        <translation>chart</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="51"/>
         <source>Käytössäsi olevan tilikartan versio</source>
-        <translation type="unfinished"></translation>
+        <translation>Version of your current chart of accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="58"/>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="72"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="65"/>
         <source>Saatavilla oleva päivitys</source>
-        <translation type="unfinished"></translation>
+        <translation>Available update</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="81"/>
         <source>Tilikartan päivittäminen päivittää tililuettelon, raportit ja tilinpäätöksen pohjatekstit.</source>
-        <translation type="unfinished"></translation>
+        <translation>Updating the chart of accounts updates the account list, reports, and financial statement templates.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="91"/>
         <source>On suositeltavaa varmuuskopioida kirjanpito ennen tilikartan päivittämistä.</source>
-        <translation type="unfinished"></translation>
+        <translation>It is recommended to back up the accounting before updating the chart of accounts.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.ui" line="116"/>
         <source>Päivitä tilikartta</source>
-        <translation type="unfinished"></translation>
+        <translation>Update chart of accounts</translation>
     </message>
     <message>
         <location filename="../tools/paivitys.ui" line="14"/>
         <source>Tilikartan päivitys</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts update</translation>
     </message>
     <message>
         <location filename="../tools/paivitys.ui" line="36"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toiminto päivittää käytössä olevan tililuettelon, raporttimallit sekä tilinpäätöksen mallin.&lt;/p&gt;&lt;p&gt;On suositeltavaa varmuuskopioida kirjanpito ennen tilikartan päivittämistä!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This function updates the current account list, report templates, and financial statement template.&lt;/p&gt;&lt;p&gt;It is recommended to back up the accounting before updating the chart of accounts!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../tools/paivitys.ui" line="63"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.cpp" line="99"/>
         <source>Tilikartta päivitetty</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts updated</translation>
     </message>
     <message>
         <location filename="../maaritys/tilikarttapaivitys.cpp" line="99"/>
         <source>Tilikartta päivitetty uuteen versioon</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts updated to new version</translation>
     </message>
 </context>
 <context>
@@ -11531,62 +11653,62 @@ ja kaupunki</source>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="20"/>
         <source>Tulostettavat tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounts to print</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="26"/>
         <source>Kaikki tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>All accounts</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="40"/>
         <source>Käytössä olevat tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Active accounts</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="54"/>
         <source>Tilit, joilla kirjauksia</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounts with entries</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="65"/>
         <source>Suosikkitilit</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorite accounts</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="81"/>
         <source>Tilikaudelta</source>
-        <translation type="unfinished"></translation>
+        <translation>For accounting period</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="94"/>
         <source>Näytä tilityypit</source>
-        <translation type="unfinished"></translation>
+        <translation>Show account types</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="105"/>
         <source>Saldot</source>
-        <translation type="unfinished"></translation>
+        <translation>Balances</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="123"/>
         <source>Kirjausohjeet</source>
-        <translation type="unfinished"></translation>
+        <translation>Posting instructions</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="134"/>
         <source>Näytä otsikot</source>
-        <translation type="unfinished"></translation>
+        <translation>Show headers</translation>
     </message>
     <message>
         <location filename="../raportti/tilikarttaraportti.ui" line="148"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
 </context>
 <context>
@@ -11594,62 +11716,62 @@ ja kaupunki</source>
     <message>
         <location filename="../arkisto/arkisto.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="38"/>
         <source>&amp;Uusi tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;New accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="45"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="55"/>
         <source>&amp;Muokkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Edit</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="69"/>
         <source>Numeroi uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Renumber</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="93"/>
         <source>Aineisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Material</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="104"/>
         <source>&amp;Arkisto</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Archive</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="111"/>
         <source>F9</source>
-        <translation type="unfinished"></translation>
+        <translation>F9</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="118"/>
         <source>&amp;Vie arkisto</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Export archive</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="142"/>
         <source>&amp;Budjetti</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Budget</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="153"/>
         <source>&amp;Tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Financial statement</translation>
     </message>
     <message>
         <location filename="../arkisto/arkisto.ui" line="160"/>
         <source>F10</source>
-        <translation type="unfinished"></translation>
+        <translation>F10</translation>
     </message>
 </context>
 <context>
@@ -11657,82 +11779,82 @@ ja kaupunki</source>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="52"/>
         <source>Tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="54"/>
         <source>Liikevaihto</source>
-        <translation type="unfinished"></translation>
+        <translation>Turnover</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="56"/>
         <source>Tase</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="58"/>
         <source>Yli/alijäämä</source>
-        <translation type="unfinished"></translation>
+        <translation>Surplus/deficit</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="60"/>
         <source>Liitteiden koko</source>
-        <translation type="unfinished"></translation>
+        <translation>Attachments size</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="62"/>
         <source>Arkistoitu</source>
-        <translation type="unfinished"></translation>
+        <translation>Archived</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="64"/>
         <source>Tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statement</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="83"/>
         <source>%1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="92"/>
         <source>Tase ei täsmää!</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet doesn&apos;t match!</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="104"/>
         <source>Vahvistettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmed</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="106"/>
         <source>Keskeneräinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Incomplete</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="108"/>
         <source>Tilinavaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening entry</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="114"/>
         <source>Ei pakollinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Not mandatory</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="116"/>
         <source>Aika laatia!</source>
-        <translation type="unfinished"></translation>
+        <translation>Time to prepare!</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="265"/>
         <source>Tilikauden tallentaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to save the accounting period</translation>
     </message>
     <message>
         <location filename="../db/tilikausimodel.cpp" line="265"/>
         <source>Virhe %1 tilikautta tallennettaessa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error %1 while saving the accounting period.</translation>
     </message>
 </context>
 <context>
@@ -11740,79 +11862,81 @@ ja kaupunki</source>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="14"/>
         <source>Muokkaa tilikautta</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="32"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tilikauden muokkaamista tarvitaan yleensä vain kirjanpidon aloittamisessa tapahtuneen virheen korjaamiseen tai erittäin poikkeukselliseen tilikauden muuttumiseen!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Huolehdi, että tilikausista muodostuu ehyt kokonaisuus. &lt;br/&gt;Joudut ehkä korjaamaan myös tositteiden numeroinnin muuttuneilla tilikausilla.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Editing the accounting period is usually needed only to correct an error made when starting the bookkeeping or for an extremely exceptional change in the accounting period!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Make sure that the accounting periods form a coherent whole. &lt;br/&gt;You may also need to correct the numbering of vouchers for the changed accounting periods.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="53"/>
         <source>Tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="68"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="80"/>
         <source>Henkilöstöä keskimäärin</source>
-        <translation type="unfinished"></translation>
+        <translation>Average number of personnel</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="96"/>
         <source>Virhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="105"/>
         <source>Tilikausi on lukittu</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period is locked</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.ui" line="116"/>
         <source>Tilikausi on tilinavausta varten</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period is for opening entry</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="57"/>
         <source>Poista tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="74"/>
         <source>Tilikauden muuttaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Changing the accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="75"/>
         <source>Oletko varma, että haluat muuttaa tilikautta?
 
 Tilikauden muuttaminen saattaa aiheuttaa tositteiden jäämistä virheellisesti tilikausien ulkopuolelle, tositteiden numeroinnin vioittumista ja muitakin ongelmia kirjanpitoon.</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to change the accounting period?
+
+Changing the accounting period may cause vouchers to be erroneously left outside the accounting periods, damage to voucher numbering, and other problems in the bookkeeping.</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="119"/>
         <source>Tilikauden loppu on ennen alkua</source>
-        <translation type="unfinished"></translation>
+        <translation>The end of the accounting period is before the beginning</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="127"/>
         <source>Tilikausi menee päällekkäin toisen tilikauden kanssa</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting period overlaps with another accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="134"/>
         <source>Kirjauksia jää tilikauden ulkopuolelle</source>
-        <translation type="unfinished"></translation>
+        <translation>Entries remain outside the accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="145"/>
         <source>Tilikauden lukitsemisen peruminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Canceling the locking of the accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="146"/>
@@ -11822,46 +11946,54 @@ Kaikki tilinpäätökseen liittyvät toimet on tehtävä uudelleen ja tilinpää
 
 Kirjanpitolaki 2. luku 7§ 2 mom:
 Tositteen, kirjanpidon tai muun kirjanpitoaineiston sisältöä ei saa muuttaa tai poistaa tilinpäätöksen laatimisen jälkeen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to cancel the locking of the accounting period?
+
+All actions related to the financial statements must be redone and the financial statements may also need to be re-confirmed.
+
+Accounting Act Chapter 2 Section 7 Paragraph 2:
+The content of a voucher, accounting records, or other accounting material must not be altered or deleted after the preparation of the financial statements.</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="173"/>
         <source>Tilinavauksen lisääminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Adding an opening balance</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="174"/>
         <source>Haluatko tehdä tästä tilikaudesta tilinavauksen?
 Sinun syötettävä tilinavaus vielä erikseen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to make this accounting period an opening balance?
+You still need to enter the opening balance separately.</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="178"/>
         <source>Tilinavauksen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Removing the opening balance</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="179"/>
         <source>Haluatko merkitä, että tämä tilikausi ei ole tilinavaus?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to mark that this accounting period is not an opening balance?</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="187"/>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="191"/>
         <source>Tilikauden poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Deleting the accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="188"/>
         <source>Oletko varma, että haluat poistaa tilikauden?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the accounting period?</translation>
     </message>
     <message>
         <location filename="../arkisto/tilikausimuokkausdlg.cpp" line="192"/>
         <source>Oletko varma, että haluat poistaa tilikauden?
 
 Tilikauden tositteita ei poisteta, mutta ne jäävät virheellisesti tilikausien ulkopuolelle eivätkä näy käyttäjälle ennen kuin niille on lisätty tilikausi.</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete the accounting period?
+
+The vouchers for the accounting period will not be deleted, but they will incorrectly remain outside the accounting periods and will not be visible to the user until an accounting period is added to them.</translation>
     </message>
 </context>
 <context>
@@ -11869,58 +12001,59 @@ Tilikauden tositteita ei poisteta, mutta ne jäävät virheellisesti tilikausien
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Anna tiedot ensimmäisestä tilikaudesta, jonka kirjaat ja jonka tilinpäätöksen teet tällä ohjelmalla.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Edellisen tilikauden &lt;/span&gt;tilinpäätöstietoja tarvitaan tilinpäätöksen lakisääteisiä vertailutietoja ja tilinavausta varten. Edellisen tilinpäätöksen tiedot syötetään ohjelmaan myöhemmin. Kirjanpidon voi aloittaa jo ennen edellisen tilikauden tietojen syöttämistä, jos esimerkiksi tilinpäätös ei ole vielä valmistunut.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the information for the first accounting period that you will record and for which you will prepare the financial statements using this program.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The previous accounting period&apos;s &lt;/span&gt;financial statement information is needed for the statutory comparative information in the financial statements and for the opening balance. The information from the previous financial statements will be entered into the program later. You can start bookkeeping even before entering the data from the previous accounting period, for example, if the financial statements have not yet been completed.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="36"/>
         <source>Ensimmäinen Kitsaalla pidettävä tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>First accounting period to be kept with Kitsas</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="50"/>
         <source>Alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Starts</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="80"/>
         <source>Päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>Ends</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="112"/>
         <source>Toiminta alkaa vasta tästä tilikaudesta (ei tilinavausta)</source>
-        <translation type="unfinished"></translation>
+        <translation>Operations start only from this accounting period (no opening balance)</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="126"/>
         <source>&lt;p&gt;&lt;b&gt;Et voi syöttää ohjelmaan taseen alkusaldoja, koska olet valinnut että toiminta alkaa vasta tästä tilikaudesta.&lt;/b&gt;&lt;/p&gt;
 &lt;p&gt;Käytä tätä valintaa vain, jos kyseessä on todellakin vasta perustetun yrityksen/yhdistyksen ensimmäinen tilikausi.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;&lt;b&gt;You cannot enter opening balances for the balance sheet into the program because you have chosen that operations start only from this accounting period.&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;Use this option only if this is indeed the first accounting period of a newly established company/association.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="142"/>
         <source>Edellinen tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous accounting period</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="155"/>
         <source>Alkoi</source>
-        <translation type="unfinished"></translation>
+        <translation>Started</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausi.ui" line="182"/>
         <source>Päättyi</source>
-        <translation type="unfinished"></translation>
+        <translation>Ended</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/tilikausisivu.cpp" line="26"/>
         <source>Tilikauden tiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period information</translation>
     </message>
 </context>
 <context>
@@ -11928,69 +12061,69 @@ Tilikauden tositteita ei poisteta, mutta ne jäävät virheellisesti tilikausien
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="84"/>
         <source>Uusi otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>New heading</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="86"/>
         <source>Uusi tili</source>
-        <translation type="unfinished"></translation>
+        <translation>New account</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="130"/>
         <source>Otsikon muokkaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit heading</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="136"/>
         <source>Poista</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="446"/>
         <source>Vahvista poisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm deletion</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="447"/>
         <source>Haluatko varmasti poistaa tämän tilin? Tarpeeton tili on yleensä suositeltavampaa piilottaa kuin poistaa.</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete this account? It&apos;s usually recommended to hide unnecessary accounts rather than delete them.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="464"/>
         <source>Uudelle tilille määritelty erityinen tilityyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Special account type defined for the new account</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="465"/>
         <source>Tilille määritelty tilityyppi %1 vaikuttaa erityisellä tavalla kirjanpidon toimintaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>The account type %1 defined for the account has a special effect on accounting operations.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="466"/>
         <source>Oletko aivan varma, että haluat lisätä tilin?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you absolutely sure you want to add the account?</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="471"/>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="478"/>
         <source>Erityistä tiliä muokattu</source>
-        <translation type="unfinished"></translation>
+        <translation>Special account modified</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="472"/>
         <source>Tilin aiempi tilityyppi %1 vaikuttaa erityisellä tavalla kirjanpidon toimintaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>The previous account type %1 of the account has a special effect on accounting operations.</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="473"/>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="480"/>
         <source>Oletko aivan varma, että haluat muuttaa tilityyppiä?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you absolutely sure you want to change the account type?</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkausdialog.cpp" line="479"/>
         <source>Tilin uusi tilityyppi %1 vaikuttaa erityisellä tavalla kirjanpidon toimintaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>The new account type %1 of the account has a special effect on accounting operations.</translation>
     </message>
 </context>
 <context>
@@ -12000,269 +12133,271 @@ Tilikauden tositteita ei poisteta, mutta ne jäävät virheellisesti tilikausien
         <location filename="../arkisto/tilinpaattaja.ui" line="373"/>
         <location filename="../arkisto/tilinpaattaja.cpp" line="136"/>
         <source>Tilinpäätöksen laatiminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Preparing financial statements</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="29"/>
         <source>Tilinpäätös tilikaudelle x - x</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statements for accounting period x - x</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="69"/>
         <source>Tiliotteiden tiliöinti ei ole valmis. 
 Kirjanpito ei täsmää. Tee tiliöinnit ennen tilinpäätöksen jatkamista.</source>
-        <translation type="unfinished"></translation>
+        <translation>Account statement entries are not complete. 
+The accounting doesn&apos;t balance. Complete the entries before continuing with the financial statements.</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="101"/>
         <source>Puutteita</source>
-        <translation type="unfinished"></translation>
+        <translation>Deficiencies</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="110"/>
         <source>Valmistavat toimet</source>
-        <translation type="unfinished"></translation>
+        <translation>Preparatory actions</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="121"/>
         <source>Kirjaa &amp;poistot...</source>
-        <translation type="unfinished"></translation>
+        <translation>Record &amp;depreciation...</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="154"/>
         <source>Ei poistettavaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Nothing to depreciate</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="161"/>
         <source>Poistot kirjattu</source>
-        <translation type="unfinished"></translation>
+        <translation>Depreciation recorded</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="183"/>
         <source>3. Tee jaksotukset</source>
-        <translation type="unfinished"></translation>
+        <translation>3. Make accruals</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="190"/>
         <source>4. Tee muut tarvittavat tilinpäätöskirjaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>4. Make other necessary closing entries</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="199"/>
         <source>Kirjaa &amp;jaksotukset...</source>
-        <translation type="unfinished"></translation>
+        <translation>Record &amp;accruals...</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="232"/>
         <source>Ei jaksotettavaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Nothing to accrue</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="239"/>
         <source>Jaksotukset kirjattu</source>
-        <translation type="unfinished"></translation>
+        <translation>Accruals recorded</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="259"/>
         <source>Uusi tilikausi avattava ennen jaksotusten tekemistä</source>
-        <translation type="unfinished"></translation>
+        <translation>New accounting period must be opened before making accruals</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="283"/>
         <source>Kirjaa tulovero...</source>
-        <translation type="unfinished"></translation>
+        <translation>Record income tax...</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="313"/>
         <source>Ei verovelvollinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Not subject to tax</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="320"/>
         <source>Tulovero kirjattu</source>
-        <translation type="unfinished"></translation>
+        <translation>Income tax recorded</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="342"/>
         <source>6. Laske ja kirjaa yhteisön tulovero</source>
-        <translation type="unfinished"></translation>
+        <translation>6. Calculate and record corporate income tax</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="349"/>
         <source>2. Tee poistokirjaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>2. Make depreciation entries</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="356"/>
         <source>1. Varmista, että kaikki tilikaudelle kuuluvat tositteet on kirjattu</source>
-        <translation type="unfinished"></translation>
+        <translation>1. Ensure all vouchers for the accounting period have been recorded</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="363"/>
         <source>5. Tarkasta raportteja tutkimalla, että kaikki kirjaukset on tehty</source>
-        <translation type="unfinished"></translation>
+        <translation>5. Review reports to verify all entries have been made</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="595"/>
         <source>&amp;Vahvista ja lukitse tilinpäätös ...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Confirm and lock financial statements...</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="379"/>
         <source>7. Lukitse kirjanpito ja muodosta arkisto</source>
-        <translation type="unfinished"></translation>
+        <translation>7. Lock the accounting and create an archive</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="388"/>
         <source>&amp;Lukitse kirjanpito ...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Lock accounting...</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="418"/>
         <source>Kirjanpito lukittu</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting locked</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="427"/>
         <source>8. Muodosta tilinpäätös ja kirjoita liitetiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>8. Prepare financial statements and write notes</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="434"/>
         <source>&amp;Liitetiedot..</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Notes..</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="448"/>
         <source>9. Tulosta tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>9. Print financial statements</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="460"/>
         <source>&amp;Tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Financial statement</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="474"/>
         <source>Kirjanpito&amp;aineisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting &amp;material</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="490"/>
         <source>Yksityistilien päättäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Closing private accounts</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="496"/>
         <source>10. Päätä yksityistilit peruspääomaan </source>
-        <translation type="unfinished"></translation>
+        <translation>10. Close private accounts to equity </translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="505"/>
         <source>Päätä yksityistilit...</source>
-        <translation type="unfinished"></translation>
+        <translation>Close private accounts...</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="532"/>
         <source>Yksityistilit päätetty</source>
-        <translation type="unfinished"></translation>
+        <translation>Private accounts closed</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="552"/>
         <source>Uusi tilikausi avattava ennen yksityistilien päättämistä</source>
-        <translation type="unfinished"></translation>
+        <translation>New accounting period must be opened before closing private accounts</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="577"/>
         <source>Tilinpäätöksen vahvistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirming financial statements</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="583"/>
         <source>10. Vahvista tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>10. Confirm financial statements</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="642"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="649"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.ui" line="669"/>
         <source>Sulje</source>
-        <translation type="unfinished"></translation>
+        <translation>Close</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="86"/>
         <source>Tilinpäätös tilikaudelle %1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statements for accounting period %1 - %2</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="98"/>
         <source>&lt;p&gt;&lt;b&gt;Tilikausi on vielä kesken&lt;/b&gt;&lt;br&gt;Jatka tilinpäätösen laatimista vain, mikäli olet täysin varma siitä, että kaikki tilikaudelle kuuluvat kirjaukset on jo tehty.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;&lt;b&gt;The accounting period is still ongoing&lt;/b&gt;&lt;br&gt;Continue preparing the financial statements only if you are absolutely certain that all entries belonging to the accounting period have already been made.</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="106"/>
         <source>&lt;p&gt;&lt;b&gt;Arvonlisäilmoitusta ei ole annettu tilikauden loppuun saakka.&lt;/b&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;&lt;b&gt;VAT return has not been submitted for the entire accounting period.&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="134"/>
         <source>&lt;p&gt;&lt;b&gt;Haluatko todella lukita tilikauden alla olevista varoituksista huolimatta: &lt;/b&gt;&lt;/p&gt; %1</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;&lt;b&gt;Do you really want to lock the accounting period despite the warnings below: &lt;/b&gt;&lt;/p&gt; %1</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="151"/>
         <source>Haluatko muodostaa lukitusta tilikaudesta sähköisen arkiston?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you want to create an electronic archive of the locked accounting period?</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="157"/>
         <source>Tilinpäätöksen päivittäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Updating the financial statement</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="158"/>
         <source>Jos olet muokannut tilinpäätökseen vaikuttavia tietoja, muodosta tilinpäätösdokumentti uudelleen &lt;b&gt;Liitetiedot&lt;/b&gt;-kohdasta.</source>
-        <translation type="unfinished"></translation>
+        <translation>If you have modified information affecting the financial statement, regenerate the financial statement document from the &lt;b&gt;Notes&lt;/b&gt; section.</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="215"/>
         <source>Vahvista tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirm financial statements</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="216"/>
         <source>Onko tilinpäätös vahvistettu lopulliseksi?
 Vahvistettua tilinpäätöstä ei voi enää muokata.</source>
-        <translation type="unfinished"></translation>
+        <translation>Has the financial statement been finalized?
+A finalized financial statement can no longer be edited.</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="269"/>
         <source>Tuloverotus yrittäjän verotuksessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Income taxation in entrepreneur&apos;s taxation</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="294"/>
         <source>11. Lukitse tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>11. Lock financial statements</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="150"/>
         <source>Tilikauden lukitseminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Locking the accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/tilinpaattaja.cpp" line="271"/>
         <source>Ei verotettavaa tuloverossa</source>
-        <translation type="unfinished"></translation>
+        <translation>No taxable income in income tax</translation>
     </message>
 </context>
 <context>
@@ -12270,37 +12405,37 @@ Vahvistettua tilinpäätöstä ei voi enää muokata.</source>
     <message>
         <location filename="../db/tilinvalintadialogi.ui" line="14"/>
         <source>Valitse tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Select account</translation>
     </message>
     <message>
         <location filename="../db/tilinvalintadialogi.ui" line="65"/>
         <source>&amp;Suosikit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Favorites</translation>
     </message>
     <message>
         <location filename="../db/tilinvalintadialogi.ui" line="79"/>
         <source>&amp;Saldolliset</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;With balance</translation>
     </message>
     <message>
         <location filename="../db/tilinvalintadialogi.ui" line="93"/>
         <source>&amp;Kaikki</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;All</translation>
     </message>
     <message>
         <location filename="../db/tilinvalintadialogi.ui" line="123"/>
         <source>Otsikot</source>
-        <translation type="unfinished"></translation>
+        <translation>Headers</translation>
     </message>
     <message>
         <location filename="../db/tilinvalintadialogi.ui" line="150"/>
         <source>Valitse</source>
-        <translation type="unfinished"></translation>
+        <translation>Select</translation>
     </message>
     <message>
         <location filename="../db/tilinvalintadialogi.ui" line="164"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
 </context>
 <context>
@@ -12308,57 +12443,57 @@ Vahvistettua tilinpäätöstä ei voi enää muokata.</source>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tilinavaus&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Syötä tilien loppusaldot edellisestä tilinpäätöksestä.&lt;br/&gt;Taseen vastaavaa ja vastattavaa syötetään pääsääntöisesti ilman etumerkkiä.&lt;br/&gt;Tuloslaskelman menot syötetään miinusmerkkisinä.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Account opening&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Enter the closing balances of accounts from the previous financial statement.&lt;br/&gt;Assets and liabilities in the balance sheet are generally entered without a sign.&lt;br/&gt;Expenses in the income statement are entered with a minus sign.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="44"/>
         <source>Tuo CSV-tiedostosta ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Import from CSV file ...</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="55"/>
         <source>Tiedot kuukausittain</source>
-        <translation type="unfinished"></translation>
+        <translation>Monthly data</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="79"/>
         <source>Siirry tiliin </source>
-        <translation type="unfinished"></translation>
+        <translation>Go to account </translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="89"/>
         <source>Tilinumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Account number</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="96"/>
         <source>Suodata tilin numerolla tai nimellä</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter by account number or name</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="103"/>
         <source>Kirjaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Entries</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="117"/>
         <source>Kaikki tilit</source>
-        <translation type="unfinished"></translation>
+        <translation>All accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.ui" line="199"/>
         <source>Henkilöstö keskimäärin</source>
-        <translation type="unfinished"></translation>
+        <translation>Average number of personnel</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.cpp" line="155"/>
         <source>Tilinavaus ei täsmää</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening balance does not match</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavaus.cpp" line="156"/>
@@ -12367,7 +12502,11 @@ Vahvistettua tilinpäätöstä ei voi enää muokata.</source>
 Tilinavaus voidaan siksi tallentaa vain luonnoksena, eikä tilinavaus näy kirjanpidon tilien saldoissa ennen kuin se on korjattu.
 
 Haluatko tallentaa tilinavauksen luonnoksena?</source>
-        <translation type="unfinished"></translation>
+        <translation>The assets and liabilities amounts in the opening balance do not match.
+
+Therefore, the opening balance can only be saved as a draft, and it will not appear in the accounting account balances until it has been corrected.
+
+Do you want to save the opening balance as a draft?</translation>
     </message>
 </context>
 <context>
@@ -12375,7 +12514,7 @@ Haluatko tallentaa tilinavauksen luonnoksena?</source>
     <message>
         <location filename="../maaritys/tilinavaus/tilinavausmodel.cpp" line="304"/>
         <source>Tilinavaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening balance</translation>
     </message>
 </context>
 <context>
@@ -12383,82 +12522,82 @@ Haluatko tallentaa tilinavauksen luonnoksena?</source>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="49"/>
         <source>Tilinpäätöksen liitetiedot %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statement notes %1</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="83"/>
         <source>Tallenna</source>
-        <translation type="unfinished"></translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="86"/>
         <source>Esikatsele</source>
-        <translation type="unfinished"></translation>
+        <translation>Preview</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="89"/>
         <source>Aloita uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Start over</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="92"/>
         <source>Valmis</source>
-        <translation type="unfinished"></translation>
+        <translation>Ready</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="95"/>
         <source>Näytä pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Show date</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="98"/>
         <source>Tulostuspäivämäärä tilinpäätöksen oikeassa yläkulmassa</source>
-        <translation type="unfinished"></translation>
+        <translation>Print date in the upper right corner of the financial statement</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="100"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="109"/>
         <source>&amp;Tilinpäätös</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Financial statement</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="170"/>
         <source>Tilinpäätöstekstin lataaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Loading financial statement text</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="170"/>
         <source>Tilinpäätöstekstin lataaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to load financial statement text</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="180"/>
         <source>Tilinpäätöstä muokattu</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statement modified</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="181"/>
         <source>Tallennetaanko muokattu tilinpäätös?</source>
-        <translation type="unfinished"></translation>
+        <translation>Save the modified financial statement?</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="258"/>
         <source>Tilinpäätös tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statement saved</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="205"/>
         <source>&lt;table width=100%&gt;&lt;tr&gt;&lt;td&gt;&lt;/td&gt;&lt;td align=center&gt;%1&lt;/td&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;table width=100%&gt;&lt;tr&gt;&lt;td&gt;&lt;/td&gt;&lt;td align=center&gt;%1&lt;/td&gt;</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatoseditori.cpp" line="209"/>
         <source>&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;%1&lt;/td&gt;&lt;td align=center&gt;%2&lt;/td&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;%1&lt;/td&gt;&lt;td align=center&gt;%2&lt;/td&gt;</translation>
     </message>
 </context>
 <context>
@@ -12466,12 +12605,12 @@ Haluatko tallentaa tilinavauksen luonnoksena?</source>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatosgeneraattori.cpp" line="233"/>
         <source>&lt;table width=100%&gt;&lt;tr&gt;&lt;th width=&quot;50%&quot;&gt;&lt;/th&gt;&lt;th align=right width=&quot;25%&quot;&gt;%1&lt;/th&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;table width=100%&gt;&lt;tr&gt;&lt;th width=&quot;50%&quot;&gt;&lt;/th&gt;&lt;th align=right width=&quot;25%&quot;&gt;%1&lt;/th&gt;</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatosgeneraattori.cpp" line="237"/>
         <source>&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;%1&lt;/td&gt;&lt;td align=right&gt;%2&lt;/td&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;%1&lt;/td&gt;&lt;td align=right&gt;%2&lt;/td&gt;</translation>
     </message>
 </context>
 <context>
@@ -12479,13 +12618,14 @@ Haluatko tallentaa tilinavauksen luonnoksena?</source>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatostulostaja.cpp" line="238"/>
         <source>Virheellinen tilinpäätöskaava</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid financial statement template</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tilinpaatostulostaja.cpp" line="239"/>
         <source>Tilinpäätöskaavan asetuksiin sisältyy raportti %1 jota ei ole olemassa.
 Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</source>
-        <translation type="unfinished"></translation>
+        <translation>The financial statement template settings include a report %1 that does not exist.
+The financial statement template must be corrected in order to print the financial statement.</translation>
     </message>
 </context>
 <context>
@@ -12493,58 +12633,58 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="41"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="51"/>
         <source>Näytä tilille jo kirjatut tapahtumat harmaalla</source>
-        <translation type="unfinished"></translation>
+        <translation>Show already recorded transactions for the account in grey</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="114"/>
         <source>&amp;Tosite...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Voucher...</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="141"/>
         <source>&amp;Kirjaa tilitapahtumia...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Record transactions...</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="155"/>
         <source>&amp;Muokkaa..</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Edit..</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="166"/>
         <source>Lisää t&amp;yhjä rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Add e&amp;mpty row</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.ui" line="180"/>
         <source>Poista rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete row</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.cpp" line="125"/>
         <source>Tiliote %1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Account statement %1 %2</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.cpp" line="177"/>
         <location filename="../apuri/tiliote/tilioteapuri.cpp" line="344"/>
         <source>Tiliote %1 - %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Account statement %1 - %2 %3</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tilioteapuri.cpp" line="261"/>
         <source>Alkusaldo %3 	Panot %1 	Otot %2 	Loppusaldo %4</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening balance %3 	Deposits %1 	Withdrawals %2 	Closing balance %4</translation>
     </message>
 </context>
 <context>
@@ -12552,233 +12692,233 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="14"/>
         <source>Tilitapahtuma</source>
-        <translation type="unfinished"></translation>
+        <translation>Transaction</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="26"/>
         <source>Etsi maksajalla tai viitenumerolla</source>
-        <translation type="unfinished"></translation>
+        <translation>Search by payer or reference number</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="171"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="259"/>
         <source>Tiliöinti</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="99"/>
         <source>Tase-erä</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet item</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="179"/>
         <source> -</source>
-        <translation type="unfinished"></translation>
+        <translation> -</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="285"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="213"/>
         <source>Lisää vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>Add entry</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="59"/>
         <source>&amp;Päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Date</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="72"/>
         <source>&amp;Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Customer</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="82"/>
         <source>&amp;Euroa</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Euros</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="112"/>
         <source>&amp;Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Allocation</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="125"/>
         <source>Me&amp;rkkaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Mar&amp;kings</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="138"/>
         <source>Se&amp;lite</source>
-        <translation type="unfinished"></translation>
+        <translation>De&amp;scription</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="164"/>
         <source>&amp;Jaksotus</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;ccrual</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="220"/>
         <source>Ins</source>
-        <translation type="unfinished"></translation>
+        <translation>Ins</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="227"/>
         <source>Poista vienti</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove entry</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="309"/>
         <source>Ei oikeuta alv-vähennykseen</source>
-        <translation type="unfinished"></translation>
+        <translation>Not eligible for VAT deduction</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="316"/>
         <source>Poistoaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Depreciation period</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="326"/>
         <source> v</source>
-        <translation type="unfinished"></translation>
+        <translation> y</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="362"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="369"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="409"/>
         <source>Kirjaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Record</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="416"/>
         <source>F12</source>
-        <translation type="unfinished"></translation>
+        <translation>F12</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="426"/>
         <source>Tyhjennä</source>
-        <translation type="unfinished"></translation>
+        <translation>Clear</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="437"/>
         <source>Sulje</source>
-        <translation type="unfinished"></translation>
+        <translation>Close</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="184"/>
         <source>Tilille</source>
-        <translation type="unfinished"></translation>
+        <translation>To account</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="64"/>
         <source>Vastatili</source>
-        <translation type="unfinished"></translation>
+        <translation>Contra account</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="184"/>
         <source>Tililtä</source>
-        <translation type="unfinished"></translation>
+        <translation>From account</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.ui" line="272"/>
         <source>Veroton</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax-free</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="119"/>
         <source>Kirjaa tiliotteelle</source>
-        <translation type="unfinished"></translation>
+        <translation>Record on bank statement</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="130"/>
         <source>Muokkaa tiliotekirjausta</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit bank statement entry</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="170"/>
         <source>Menotili</source>
-        <translation type="unfinished"></translation>
+        <translation>Expense account</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="170"/>
         <source>Tulotili</source>
-        <translation type="unfinished"></translation>
+        <translation>Income account</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="171"/>
         <source>Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Supplier</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="185"/>
         <source>Saaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Recipient</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="185"/>
         <source>Maksaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Payer</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="295"/>
         <source>Maksett&amp;u lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Paid invoice</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="298"/>
         <source>&amp;Meno</source>
-        <translation type="unfinished"></translation>
+        <translation>E&amp;xpense</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="302"/>
         <source>Saap&amp;uva maksu</source>
-        <translation type="unfinished"></translation>
+        <translation>Incoming pa&amp;yment</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="305"/>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="505"/>
         <source>&amp;Tulo</source>
-        <translation type="unfinished"></translation>
+        <translation>Inco&amp;me</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="307"/>
         <source>&amp;Vakioviite</source>
-        <translation type="unfinished"></translation>
+        <translation>Standard re&amp;ference</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="501"/>
         <source>T&amp;ilille</source>
-        <translation type="unfinished"></translation>
+        <translation>To acco&amp;unt</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="502"/>
         <source>Tililt&amp;ä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;From account</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="504"/>
         <source>Lask&amp;un maksu</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice paymen&amp;t</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjaaja.cpp" line="506"/>
         <source>&amp;Siirto</source>
-        <translation type="unfinished"></translation>
+        <translation>T&amp;ransfer</translation>
     </message>
 </context>
 <context>
@@ -12786,47 +12926,47 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
     <message>
         <location filename="../apuri/tiliote/tiliotemodel.cpp" line="43"/>
         <source>Pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotemodel.cpp" line="45"/>
         <source>Euro</source>
-        <translation type="unfinished"></translation>
+        <translation>Euro</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotemodel.cpp" line="47"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotemodel.cpp" line="49"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotemodel.cpp" line="51"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotemodel.cpp" line="53"/>
         <source>Saaja/Maksaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Recipient/Payer</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotemodel.cpp" line="55"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjausrivi.cpp" line="209"/>
         <source>Uusi erä</source>
-        <translation type="unfinished"></translation>
+        <translation>New entry</translation>
     </message>
     <message>
         <location filename="../apuri/tiliote/tiliotekirjausrivi.cpp" line="222"/>
         <source>Ei tase-erää</source>
-        <translation type="unfinished"></translation>
+        <translation>No balance sheet item</translation>
     </message>
 </context>
 <context>
@@ -12834,7 +12974,7 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
     <message>
         <location filename="../apuri/tiliote/tilioteviennit.cpp" line="33"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
 </context>
 <context>
@@ -12842,69 +12982,70 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="14"/>
         <source>Kirjaudu Kitsaaseen</source>
-        <translation type="unfinished"></translation>
+        <translation>Log in to Kitsas</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="33"/>
         <location filename="../aloitussivu/toffeelogin.ui" line="74"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="40"/>
         <source>&lt;p&gt;Copyright &amp;copy; Arto Hyvättinen ja Kitsas Oy 2017 - 2024&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;Copyright &amp;copy; Arto Hyvättinen and Kitsas Oy 2017 - 2024&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="47"/>
         <source>&lt;p&gt;Ohjelmaa saa käyttää, kopioida, levittää ja muokata maksutta GNU General Public License 3:n ehtojen mukaisesti, katso tarkemmin &lt;a href=&quot;https://kitsas.fi/docs/lisenssi&quot;&gt;kitsas.fi/docs/lisenssi&lt;/a&gt;, jossa myös tiedot ohjelman käyttämien avoimen lähdekoodin komponenttien käyttöehdoista.&lt;/p&gt;
 &lt;p&gt;Ohjelmalla ei ole mitään takuuta.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;The program can be used, copied, distributed, and modified free of charge under the terms of GNU General Public License 3, see more at &lt;a href=&quot;https://kitsas.fi/docs/lisenssi&quot;&gt;kitsas.fi/docs/lisenssi&lt;/a&gt;, which also includes information about the terms of use for the open-source components used by the program.&lt;/p&gt;
+&lt;p&gt;The program comes with no warranty.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="83"/>
         <source>Sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="96"/>
         <source>Salasana</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="113"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="124"/>
         <source>suomi</source>
-        <translation type="unfinished"></translation>
+        <translation>Finnish</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="133"/>
         <source>ruotsi</source>
-        <translation type="unfinished"></translation>
+        <translation>Swedish</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="145"/>
         <source>Muista minut</source>
-        <translation type="unfinished"></translation>
+        <translation>Remember me</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="169"/>
         <source>Lopeta</source>
-        <translation type="unfinished"></translation>
+        <translation>Exit</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="180"/>
         <source>Unohdin salasanan</source>
-        <translation type="unfinished"></translation>
+        <translation>Forgot password</translation>
     </message>
     <message>
         <location filename="../aloitussivu/toffeelogin.ui" line="204"/>
         <source>Kirjaudu</source>
-        <translation type="unfinished"></translation>
+        <translation>Log in</translation>
     </message>
 </context>
 <context>
@@ -12912,167 +13053,167 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="25"/>
         <source>Yhteystiedot ja toiminimet</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact information and trade names</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="34"/>
         <source>Muokkaa tietoja toiminimelle</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit information for trade name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="44"/>
         <source>Poista aputoiminimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove auxiliary trade name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="58"/>
         <source>Uusi aputoiminimi</source>
-        <translation type="unfinished"></translation>
+        <translation>New auxiliary trade name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="74"/>
         <source>Yhteystiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact information</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="80"/>
         <source>Toiminimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Trade name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="90"/>
         <source>Katuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Street address</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="107"/>
         <source>Postiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Postal address</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="124"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="134"/>
         <source>Kotisivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Homepage</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="144"/>
         <source>Puhelinnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="157"/>
         <source>Logo</source>
-        <translation type="unfinished"></translation>
+        <translation>Logo</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="192"/>
         <source>Vaihda logo</source>
-        <translation type="unfinished"></translation>
+        <translation>Change logo</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="203"/>
         <source>Poista logo</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove logo</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="218"/>
         <source>Logon sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Logo position</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="228"/>
         <source>Logon korkeus laskuilla</source>
-        <translation type="unfinished"></translation>
+        <translation>Logo height on invoices</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="235"/>
         <source> mm</source>
-        <translation type="unfinished"></translation>
+        <translation> mm</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="266"/>
         <source>Laskun tehostevärit</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice accent colors</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="272"/>
         <source>Kehyksen väri</source>
-        <translation type="unfinished"></translation>
+        <translation>Frame color</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.ui" line="286"/>
         <source>Varjostus</source>
-        <translation type="unfinished"></translation>
+        <translation>Shadow</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="119"/>
         <source>Aputoiminimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Auxiliary business name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="119"/>
         <source>Organisaation nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Organization name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="34"/>
         <source>Logo nimen vieressä</source>
-        <translation type="unfinished"></translation>
+        <translation>Logo next to name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="35"/>
         <source>Logo nimen yläpuolella</source>
-        <translation type="unfinished"></translation>
+        <translation>Logo above name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="36"/>
         <source>Näytä vain logo</source>
-        <translation type="unfinished"></translation>
+        <translation>Show only logo</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="166"/>
         <source>Lisää aputoiminimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Add auxiliary business name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="167"/>
         <source>Lisättävä aputoiminimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Auxiliary business name to be added</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="191"/>
         <source>Aputoiminimen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove auxiliary business name</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="192"/>
         <source>Haluatko todella poistaa aputoiminimen %1 ?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to delete the auxiliary business name %1?</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="207"/>
         <source>Kuvatiedostot (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
+        <translation>Image files (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="224"/>
         <source>Logon poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove logo</translation>
     </message>
     <message>
         <location filename="../maaritys/toiminimimaaritys.cpp" line="225"/>
         <source>Haluatko todella poistaa tämän logon?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to delete this logo?</translation>
     </message>
 </context>
 <context>
@@ -13080,37 +13221,37 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
     <message>
         <location filename="../laskutus/ryhmalasku/toimitustapadelegaatti.cpp" line="54"/>
         <source>Tulosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/toimitustapadelegaatti.cpp" line="56"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/toimitustapadelegaatti.cpp" line="58"/>
         <source>Postitus</source>
-        <translation type="unfinished"></translation>
+        <translation>Mailing</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/toimitustapadelegaatti.cpp" line="60"/>
         <source>Verkkolasku</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/toimitustapadelegaatti.cpp" line="62"/>
         <source>PDF</source>
-        <translation type="unfinished"></translation>
+        <translation>PDF</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/toimitustapadelegaatti.cpp" line="64"/>
         <source>Ei tulosteta</source>
-        <translation type="unfinished"></translation>
+        <translation>Not printed</translation>
     </message>
     <message>
         <location filename="../laskutus/ryhmalasku/toimitustapadelegaatti.cpp" line="66"/>
         <source>Tuotu lasku</source>
-        <translation type="unfinished"></translation>
+        <translation>Imported invoice</translation>
     </message>
 </context>
 <context>
@@ -13121,30 +13262,33 @@ Tilinpäätöksen kaavaa on korjattava jotta tilinpäätöksen voi tulostaa.</so
         <location filename="../model/tosite.cpp" line="417"/>
         <location filename="../model/tosite.cpp" line="426"/>
         <source>Virheellinen tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid voucher</translation>
     </message>
     <message>
         <location filename="../model/tosite.cpp" line="400"/>
         <source>Arvonlisäverottomaan kirjanpitoon ei pitäisi tehdä arvonlisäverollista kirjausta. 
  Tallennetaanko tosite silti?</source>
-        <translation type="unfinished"></translation>
+        <translation>An entry with VAT should not be made in VAT-exempt accounting.
+Do you still want to save the voucher?</translation>
     </message>
     <message>
         <location filename="../model/tosite.cpp" line="410"/>
         <source>Tilille %1 syötetty tase-erä, vaikka tilillä ei ole tase-erittelyä. 
 Tallennetaanko tosite silti?</source>
-        <translation type="unfinished"></translation>
+        <translation>A balance sheet item has been entered for account %1, although the account does not have a balance sheet breakdown.
+Do you want to save the voucher anyway?</translation>
     </message>
     <message>
         <location filename="../model/tosite.cpp" line="417"/>
         <source>Tilillä %1 on käytetty asiakas- tai huoneistokohtaista erittelyä, mikä on tarkoitettu ainoastaa myyntisaamisten käsittelyyn. Tällaisesta kirjauksesta muodostuu virheellinen tase.erittely. 
 Tallennetaanko tosite silti?</source>
-        <translation type="unfinished"></translation>
+        <translation>Account %1 uses customer or apartment-specific specification, which is intended only for handling accounts receivable. This kind of entry will create an incorrect balance sheet specification.
+Do you still want to save the voucher?</translation>
     </message>
     <message>
         <location filename="../model/tosite.cpp" line="427"/>
         <source>Tositteen debet ja kredit eivät täsmää</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit and credit of the voucher do not match</translation>
     </message>
 </context>
 <context>
@@ -13152,17 +13296,17 @@ Tallennetaanko tosite silti?</source>
     <message>
         <location filename="../model/tositeloki.cpp" line="50"/>
         <source>Muokattu</source>
-        <translation type="unfinished"></translation>
+        <translation>Modified</translation>
     </message>
     <message>
         <location filename="../model/tositeloki.cpp" line="52"/>
         <source>Käyttäjä</source>
-        <translation type="unfinished"></translation>
+        <translation>User</translation>
     </message>
     <message>
         <location filename="../model/tositeloki.cpp" line="54"/>
         <source>Tila</source>
-        <translation type="unfinished"></translation>
+        <translation>Status</translation>
     </message>
 </context>
 <context>
@@ -13170,100 +13314,100 @@ Tallennetaanko tosite silti?</source>
     <message>
         <location filename="../model/tositerivit.cpp" line="58"/>
         <source>Nimike</source>
-        <translation type="unfinished"></translation>
+        <translation>Item</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="60"/>
         <source>Määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Quantity</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="62"/>
         <source>Yksikkö</source>
-        <translation type="unfinished"></translation>
+        <translation>Unit</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="64"/>
         <source>á hinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Price per unit</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="64"/>
         <source>á netto</source>
-        <translation type="unfinished"></translation>
+        <translation>Net price per unit</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="66"/>
         <source>Alennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Discount</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="68"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="70"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="72"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="74"/>
         <source>Yhteensä</source>
-        <translation type="unfinished"></translation>
+        <translation>Total</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="74"/>
         <source>Yht netto</source>
-        <translation type="unfinished"></translation>
+        <translation>Total net</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="139"/>
         <source>0 %</source>
-        <translation type="unfinished"></translation>
+        <translation>0 %</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="141"/>
         <source>AVL 8c §</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT Act 8c §</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="143"/>
         <source>AVL 65 §</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT Act 65 §</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="145"/>
         <source>AVL 72a §</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT Act 72a §</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="147"/>
         <source>Margin. tavarat</source>
         <comment>Marginaaliverotus käytetyt tavarat/ Lyhyt teksti laskunäkymässä</comment>
-        <translation type="unfinished"></translation>
+        <translation>Margin scheme goods</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="149"/>
         <source>Margin. taide</source>
         <comment>Marginaaliverotus taide-esineet/ Lyhyt teksti laskunäkymässä</comment>
-        <translation type="unfinished"></translation>
+        <translation>Margin scheme art</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="151"/>
         <source>Margin. keräily</source>
         <comment>Marginaaliverotus keräily- ja antiikkiesineet/ Lyhyt teksti laskunäkymässä</comment>
-        <translation type="unfinished"></translation>
+        <translation>Margin scheme collectibles</translation>
     </message>
     <message>
         <location filename="../model/tositerivit.cpp" line="165"/>
         <source>Saadut ennakot</source>
-        <translation type="unfinished"></translation>
+        <translation>Received advances</translation>
     </message>
 </context>
 <context>
@@ -13271,42 +13415,42 @@ Tallennetaanko tosite silti?</source>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="68"/>
         <source>Tila</source>
-        <translation type="unfinished"></translation>
+        <translation>Status</translation>
     </message>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="70"/>
         <source>Tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher</translation>
     </message>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="72"/>
         <source>Pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="74"/>
         <source>Laji</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="76"/>
         <source>Summa</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount</translation>
     </message>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="78"/>
         <source>Asiakas/Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/Supplier</translation>
     </message>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="80"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../selaus/tositeselausmodel.cpp" line="272"/>
         <source>Lähettäminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Sending failed</translation>
     </message>
 </context>
 <context>
@@ -13314,87 +13458,92 @@ Tallennetaanko tosite silti?</source>
     <message>
         <location filename="../model/tositeviennit.cpp" line="46"/>
         <source>Pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="48"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="50"/>
         <source>Debet</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="52"/>
         <source>Kredit</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="54"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="56"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="58"/>
         <source>Asiakas/Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer/Supplier</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="60"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="124"/>
         <source>VERO</source>
-        <translation type="unfinished"></translation>
+        <translation>TAX</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="144"/>
         <source>Uusi erä</source>
-        <translation type="unfinished"></translation>
+        <translation>New entry</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="160"/>
         <source>Ei tase-erää</source>
-        <translation type="unfinished"></translation>
+        <translation>No balance sheet item</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="654"/>
         <source>
 Myynneistä pitäisi tilittää arvonlisäveroa %L1 €</source>
-        <translation type="unfinished"></translation>
+        <translation>
+VAT to be paid on sales: %L1 €</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="656"/>
         <source>
 Ostoista pitäisi vähentää arvonlisäveroa %L1 €</source>
-        <translation type="unfinished"></translation>
+        <translation>
+VAT to be deducted from purchases: %L1 €</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="658"/>
         <source>
 Palveluiden yhteisöhankinnoista pitäisi tilittää arvonlisäveroa %L1 €</source>
-        <translation type="unfinished"></translation>
+        <translation>
+VAT to be paid on intra-community acquisitions of services: %L1 €</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="660"/>
         <source>
 Tavaroiden yhteisöhankinnoista pitäisi tilittää arvonlisäveroa %L1 €</source>
-        <translation type="unfinished"></translation>
+        <translation>
+VAT to be paid on intra-community acquisitions of goods: %L1 €</translation>
     </message>
     <message>
         <location filename="../model/tositeviennit.cpp" line="662"/>
         <source>
 Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source>
-        <translation type="unfinished"></translation>
+        <translation>
+VAT to be paid on purchases of construction services: %L1 €</translation>
     </message>
 </context>
 <context>
@@ -13402,42 +13551,42 @@ Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source
     <message>
         <location filename="../kirjaus/tositewg.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../kirjaus/tositewg.ui" line="20"/>
         <source>Mallipohjat</source>
-        <translation type="unfinished"></translation>
+        <translation>Templates</translation>
     </message>
     <message>
         <location filename="../kirjaus/tositewg.ui" line="32"/>
         <source>Sähköinen tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Electronic voucher</translation>
     </message>
     <message>
         <location filename="../kirjaus/tositewg.ui" line="48"/>
         <source>Raahaa tähän pdf-, jpg- tai csv-tiedosto tai..</source>
-        <translation type="unfinished"></translation>
+        <translation>Drag a pdf, jpg or csv file here or..</translation>
     </message>
     <message>
         <location filename="../kirjaus/tositewg.ui" line="73"/>
         <source>Valitse tiedosto</source>
-        <translation type="unfinished"></translation>
+        <translation>Select file</translation>
     </message>
     <message>
         <location filename="../kirjaus/tositewg.ui" line="80"/>
         <source>Ctrl+O</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+O</translation>
     </message>
     <message>
         <location filename="../kirjaus/tositewg.ui" line="87"/>
         <source>Liitä leikepöydältä</source>
-        <translation type="unfinished"></translation>
+        <translation>Paste from clipboard</translation>
     </message>
     <message>
         <location filename="../kirjaus/tositewg.ui" line="94"/>
         <source>Ctrl+V</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+V</translation>
     </message>
 </context>
 <context>
@@ -13445,7 +13594,7 @@ Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source
     <message>
         <location filename="../maaritys/tositesarjamaaritys.cpp" line="59"/>
         <source>Järjestelmätositteet</source>
-        <translation type="unfinished"></translation>
+        <translation>System vouchers</translation>
     </message>
 </context>
 <context>
@@ -13453,37 +13602,37 @@ Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source
     <message>
         <location filename="../maaritys/tositesarjat.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/tositesarjat.ui" line="26"/>
         <source>Tositesarjat</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher series</translation>
     </message>
     <message>
         <location filename="../maaritys/tositesarjat.ui" line="39"/>
         <source>Numeroi tositteet samaan sarjaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Number vouchers in the same series</translation>
     </message>
     <message>
         <location filename="../maaritys/tositesarjat.ui" line="50"/>
         <source>Numeroi tositetyypeittäin omiin sarjoihinsa</source>
-        <translation type="unfinished"></translation>
+        <translation>Number by voucher type in their own series</translation>
     </message>
     <message>
         <location filename="../maaritys/tositesarjat.ui" line="63"/>
         <source>Numeroi käteistositteet omaan sarjaansa</source>
-        <translation type="unfinished"></translation>
+        <translation>Number cash vouchers in their own series</translation>
     </message>
     <message>
         <location filename="../maaritys/tositesarjat.ui" line="85"/>
         <source>Tositetyyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Voucher type</translation>
     </message>
     <message>
         <location filename="../maaritys/tositesarjat.ui" line="90"/>
         <source>Sarjan tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Series identifier</translation>
     </message>
 </context>
 <context>
@@ -13491,109 +13640,110 @@ Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="14"/>
         <source>Tilinpäätösasiakirjan muodostaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating the financial statement document</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tee tilinpäätökseen tulostuviin tietoihin liittyvät valinnat.&lt;/p&gt;&lt;p&gt;Jos olet tehnyt vahvistetun tilinpäätöksen muulla ohjelmalla, lataa pdf-tiedosto Kitsaan arkistoon valitsemalla &lt;span style=&quot; font-weight:600;&quot;&gt;Lataa tiedosto&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make selections related to the information printed in the financial statements.&lt;/p&gt;&lt;p&gt;If you have made a confirmed financial statement with another program, upload the pdf file to the Kitsas archive by selecting &lt;span style=&quot; font-weight:600;&quot;&gt;Upload file&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="32"/>
         <source>Tilinpäätöksen kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language of the financial statement</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="45"/>
         <source>Henkilökuntaa keskimäärin</source>
-        <translation type="unfinished"></translation>
+        <translation>Average number of personnel</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="64"/>
         <source>Tilinpäätöksessä sovellettava säännöstö</source>
-        <translation type="unfinished"></translation>
+        <translation>Regulations applied in the financial statements</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="70"/>
         <source>Mikroyritys</source>
-        <translation type="unfinished"></translation>
+        <translation>Micro-enterprise</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="77"/>
         <source>Pienyritys</source>
-        <translation type="unfinished"></translation>
+        <translation>Small enterprise</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="84"/>
         <source>Ei pien- eikä mikroyritys</source>
-        <translation type="unfinished"></translation>
+        <translation>Neither small nor micro-enterprise</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="97"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pienelle elinkeinonharjoittajalle tilinpäätöksen laatiminen on vapaaehtoista.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For small entrepreneurs, preparing financial statements is voluntary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="109"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="116"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation>F1</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="136"/>
         <source>&amp;Jatka</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Continue</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="150"/>
         <source>&amp;Lataa tiedosto</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Load file</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.ui" line="161"/>
         <source>Keskeytä</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="111"/>
         <source>Valitse tilinpäätöstiedosto</source>
-        <translation type="unfinished"></translation>
+        <translation>Select financial statement file</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="112"/>
         <source>Pdf-tiedostot (*.pdf)</source>
-        <translation type="unfinished"></translation>
+        <translation>PDF files (*.pdf)</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="117"/>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="123"/>
         <source>Tiedostovirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>File error</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="117"/>
         <source>Tiedoston %1 luku epäonnistui
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to read file %1
+%2</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="123"/>
         <source>Tiedoston koko on liian suuri. Voit lisätä enintään 10 megatavun kokoisen tiedoston.</source>
-        <translation type="unfinished"></translation>
+        <translation>The file size is too large. You can add a file up to 10 megabytes in size.</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="140"/>
         <source>Tilinpäätös tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial statement saved</translation>
     </message>
     <message>
         <location filename="../tilinpaatoseditori/tpaloitus.cpp" line="141"/>
         <source>Laatimasi tilinpäätös on tallennettu kirjanpitoon.</source>
-        <translation type="unfinished"></translation>
+        <translation>The financial statement you prepared has been saved to the accounting records.</translation>
     </message>
 </context>
 <context>
@@ -13601,38 +13751,38 @@ Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source
     <message>
         <location filename="../aloitussivu/tukiwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tukiwidget.ui" line="20"/>
         <source>Käyttäjätunnuksesi</source>
-        <translation type="unfinished"></translation>
+        <translation>Your username</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tukiwidget.ui" line="31"/>
         <location filename="../aloitussivu/tukiwidget.ui" line="38"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tukiwidget.ui" line="86"/>
         <source>&lt;b&gt;Ohjeet&lt;/b&gt;&lt;br/&gt;Lue Kitsaan ohjeita ja katso ohjevideoita</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Instructions&lt;/b&gt;&lt;br/&gt;Read Kitsas instructions and watch tutorial videos</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tukiwidget.ui" line="113"/>
         <source>&lt;b&gt;Tuen yhteystiedot&lt;/b&gt;&lt;br/&gt;Neuvontaa sähköpostilla ja puhelimella. Vain tilaajille.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Support contact information&lt;/b&gt;&lt;br/&gt;Guidance via email and phone. For subscribers only.</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tukiwidget.ui" line="140"/>
         <source>&lt;b&gt;Palaute&lt;/b&gt;&lt;br/&gt;Anna palautetta Kitsaan kehittäjille</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Feedback&lt;/b&gt;&lt;br/&gt;Give feedback to Kitsas developers</translation>
     </message>
     <message>
         <location filename="../aloitussivu/tukiwidget.ui" line="167"/>
         <source>&lt;b&gt;Tekniset tiedot&lt;/b&gt;&lt;br/&gt;Lähetä teknisiä tietoja tuelle tuen niitä erikseen pyytäessä.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Technical information&lt;/b&gt;&lt;br/&gt;Send technical information to support when specifically requested by support.</translation>
     </message>
 </context>
 <context>
@@ -13640,163 +13790,163 @@ Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="24"/>
         <source>M&amp;aksutapa</source>
-        <translation type="unfinished"></translation>
+        <translation>P&amp;ayment method</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="42"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="52"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="64"/>
         <location filename="../apuri/tulomenoapuri.cpp" line="793"/>
         <source>Toimittaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Supplier</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="78"/>
         <source>Laskun &amp;numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice &amp;number</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="91"/>
         <source>&amp;Laskun pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Invoice date</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="104"/>
         <source>&amp;Eräpäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Due date</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="117"/>
         <source>Viite</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="130"/>
         <source>Vastat&amp;ili</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Contra account</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="143"/>
         <source>Tase&amp;-erä</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Balance sheet item</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="184"/>
         <source>&amp;Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Account</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="197"/>
         <source>M&amp;äärä</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;mount</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="210"/>
         <source>V&amp;eroton</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Tax-free</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="223"/>
         <source>&amp;Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;VAT</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="247"/>
         <source>&amp;Ei oikeuta alv-vähennykseen</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Not eligible for VAT deduction</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="254"/>
         <source>&amp;Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;llocation</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="267"/>
         <source>&amp;Merkkaukset</source>
-        <translation type="unfinished"></translation>
+        <translation>Ta&amp;gs</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="284"/>
         <source>&amp;Jaksotus</source>
-        <translation type="unfinished"></translation>
+        <translation>Acc&amp;rual</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="299"/>
         <source> - </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apuri/tulomenoapuri.ui" line="318"/>
-        <source>&amp;Poistoaika</source>
-        <translation type="unfinished"></translation>
+        <translation> - </translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="328"/>
         <source> vuotta</source>
-        <translation type="unfinished"></translation>
+        <translation> year(s)</translation>
+    </message>
+    <message>
+        <location filename="../apuri/tulomenoapuri.ui" line="318"/>
+        <source>&amp;Poistoaika</source>
+        <translation>Depreciation &amp;period</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="341"/>
         <source>R&amp;iviselite</source>
-        <translation type="unfinished"></translation>
+        <translation>Ro&amp;w description</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="387"/>
         <source>Lisää rivin   Ins</source>
-        <translation type="unfinished"></translation>
+        <translation>Add row   Ins</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="390"/>
         <source>Lisää rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Add row</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="397"/>
         <source>Ins</source>
-        <translation type="unfinished"></translation>
+        <translation>Ins</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.ui" line="407"/>
         <source>Poista rivi</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete row</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.cpp" line="791"/>
         <source>Meno&amp;tili</source>
-        <translation type="unfinished"></translation>
+        <translation>E&amp;xpense account</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.cpp" line="796"/>
         <source>Laskuttaja</source>
-        <translation type="unfinished"></translation>
+        <translation>Biller</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.cpp" line="798"/>
         <source>Tulo&amp;tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Income acco&amp;unt</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.cpp" line="801"/>
         <source>Asiakas</source>
-        <translation type="unfinished"></translation>
+        <translation>Customer</translation>
     </message>
     <message>
         <location filename="../apuri/tulomenoapuri.cpp" line="899"/>
         <source>Kululasku %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Expense invoice %1</translation>
     </message>
 </context>
 <context>
@@ -13805,112 +13955,114 @@ Rakennuspalveluiden ostoista pitäisi tilittää arvonlisäveroa %L1 €</source
         <location filename="../arkisto/tuloverodialog.ui" line="14"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="82"/>
         <source>Tuloveron kirjaaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Recording income tax</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="25"/>
         <source>Tutustu huolella verotukseen liittyviin ohjeisiin ja täydennä alla oleva laskelma.</source>
-        <translation type="unfinished"></translation>
+        <translation>Carefully review the tax-related instructions and complete the calculation below.</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="35"/>
         <source>Vain yksinkertaisimmissa tapauksissa ohjelman tekemä laskelma on sellaisenaan oikea.</source>
-        <translation type="unfinished"></translation>
+        <translation>Only in the simplest cases is the calculation made by the program correct as it is.</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="67"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="185"/>
         <source>Kokonaan vähennyskelpoiset kulut</source>
-        <translation type="unfinished"></translation>
+        <translation>Fully deductible expenses</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="139"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="192"/>
         <source>Lopullinen verotettava tulos</source>
-        <translation type="unfinished"></translation>
+        <translation>Final taxable result</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="156"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="190"/>
         <source>Vähennettävä aiempi tappio</source>
-        <translation type="unfinished"></translation>
+        <translation>Deductible previous loss</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="173"/>
         <source>Puoliksi vähennyskelpoiset kulut</source>
-        <translation type="unfinished"></translation>
+        <translation>Half-deductible expenses</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="47"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="193"/>
         <source>Tuloveron määrä</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount of income tax</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="100"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="196"/>
         <source>Maksamaton tulovero</source>
-        <translation type="unfinished"></translation>
+        <translation>Unpaid income tax</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="110"/>
         <source>Maksetut ennakkoverot</source>
-        <translation type="unfinished"></translation>
+        <translation>Paid advance taxes</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="80"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="183"/>
         <source>Veronalainen tulo yhteensä</source>
-        <translation type="unfinished"></translation>
+        <translation>Total taxable income</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.ui" line="57"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="189"/>
         <source>Verotettava tulos</source>
-        <translation type="unfinished"></translation>
+        <translation>Taxable profit</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="83"/>
         <source>Ennakkovero täsmää täysin tuloveroon, eikä tuloveroa jää myöhemmin tilitettäväksi.
 Tallenna veroilmoituksesi osaksi kirjanpitoa.</source>
-        <translation type="unfinished"></translation>
+        <translation>The advance tax matches the income tax exactly, and no income tax remains to be paid later.
+Save your tax return as part of your accounting.</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="94"/>
         <location filename="../arkisto/tuloverodialog.cpp" line="97"/>
         <source>Tuloveron jaksotus tilikaudelta %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Income tax accrual for accounting period %1</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="166"/>
         <source>Tuloveron kirjaus tallennettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Income tax entry saved</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="167"/>
         <source>Tuloverot on kirjattu.
 Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Income taxes have been recorded.
+Keep your tax return and any tax calculations with your accounting records.</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="176"/>
         <source>Tuloverolaskelma</source>
-        <translation type="unfinished"></translation>
+        <translation>Income tax calculation</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="186"/>
         <source>Puoleksi vähennyskelpoiset kulut</source>
-        <translation type="unfinished"></translation>
+        <translation>Half-deductible expenses</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="187"/>
         <source>Vähennyskelpoiset kulut yhteensä</source>
-        <translation type="unfinished"></translation>
+        <translation>Total deductible expenses</translation>
     </message>
     <message>
         <location filename="../arkisto/tuloverodialog.cpp" line="195"/>
         <source>Maksetut tuloverot</source>
-        <translation type="unfinished"></translation>
+        <translation>Paid income taxes</translation>
     </message>
 </context>
 <context>
@@ -13918,130 +14070,130 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="506"/>
         <source>Teksti</source>
-        <translation type="unfinished"></translation>
+        <translation>Text</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="508"/>
         <source>Luku ja teksti</source>
-        <translation type="unfinished"></translation>
+        <translation>Number and text</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="510"/>
         <source>Luku</source>
-        <translation type="unfinished"></translation>
+        <translation>Number</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="512"/>
         <source>Pieni luku</source>
-        <translation type="unfinished"></translation>
+        <translation>Small number</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="514"/>
         <source>Rahamäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount of money</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="516"/>
         <location filename="../tuonti/csvtuonti.cpp" line="547"/>
         <source>IBAN-tilinumero</source>
-        <translation type="unfinished"></translation>
+        <translation>IBAN account number</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="518"/>
         <location filename="../tuonti/csvtuonti.cpp" line="549"/>
         <source>Viitenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference number</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="523"/>
         <location filename="../tuonti/csvtuonti.cpp" line="533"/>
         <source>Päivämäärä</source>
-        <translation type="unfinished"></translation>
+        <translation>Date</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="535"/>
         <source>Tositteen tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Document identifier</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="537"/>
         <source>Tilin numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Account number</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="539"/>
         <source>Debet euroa</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit euros</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="541"/>
         <source>Kredit euroa</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit euros</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="543"/>
         <source>Selite</source>
-        <translation type="unfinished"></translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="545"/>
         <source>Määrä euroa</source>
-        <translation type="unfinished"></translation>
+        <translation>Amount in euros</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="551"/>
         <source>Arkistotunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Archive identifier</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="553"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="555"/>
         <source>Tilin nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Account name</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="557"/>
         <source>Alv % Bruttokirjaus</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT % Gross entry</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="559"/>
         <source>Saajan/Maksajan nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Recipient/Payer name</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="561"/>
         <source>Tapahtuman lajikoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>Transaction type code</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="563"/>
         <source>Alv %</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT %</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="565"/>
         <source>Alvkoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT code</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="567"/>
         <source>Debet-tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Debit account</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="569"/>
         <source>Kredit-tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Credit account</translation>
     </message>
     <message>
         <location filename="../tuonti/csvtuonti.cpp" line="571"/>
         <source>Sentit</source>
-        <translation type="unfinished"></translation>
+        <translation>Cents</translation>
     </message>
 </context>
 <context>
@@ -14049,47 +14201,47 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="14"/>
         <source>Tuote</source>
-        <translation type="unfinished"></translation>
+        <translation>Product</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="20"/>
         <source>Nimike</source>
-        <translation type="unfinished"></translation>
+        <translation>Item</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="27"/>
         <source>Yksikkö</source>
-        <translation type="unfinished"></translation>
+        <translation>Unit</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="34"/>
         <source>Nettohinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Net price</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="47"/>
         <source>Alv</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="60"/>
         <source>Bruttohinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Gross price</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="73"/>
         <source>Myyntitili</source>
-        <translation type="unfinished"></translation>
+        <translation>Sales account</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="86"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotedialogi.ui" line="139"/>
         <source>Tuotekoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>Product code</translation>
     </message>
 </context>
 <context>
@@ -14097,17 +14249,17 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../laskutus/tuotemodel.cpp" line="52"/>
         <source>Nimike</source>
-        <translation type="unfinished"></translation>
+        <translation>Item</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotemodel.cpp" line="54"/>
         <source>Nettohinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Net price</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotemodel.cpp" line="56"/>
         <source>Bruttohinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Gross price</translation>
     </message>
 </context>
 <context>
@@ -14115,7 +14267,7 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontidialogi.cpp" line="44"/>
         <source>Otsikot ensimmäisellä rivillä</source>
-        <translation type="unfinished"></translation>
+        <translation>Headings on the first row</translation>
     </message>
 </context>
 <context>
@@ -14123,47 +14275,47 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="29"/>
         <source>Nimike</source>
-        <translation type="unfinished"></translation>
+        <translation>Item</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="30"/>
         <source>Yksikkö</source>
-        <translation type="unfinished"></translation>
+        <translation>Unit</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="31"/>
         <source>Hinta á netto</source>
-        <translation type="unfinished"></translation>
+        <translation>Price per unit net</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="32"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="33"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="34"/>
         <source>Alv-koodi</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT code</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="35"/>
         <source>Alv-prosentti</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT percentage</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="36"/>
         <source>Bruttohinta</source>
-        <translation type="unfinished"></translation>
+        <translation>Gross price</translation>
     </message>
     <message>
         <location filename="../laskutus/tuotetuonti/tuotetuontimodel.cpp" line="37"/>
         <source>Tuotekoodi</source>
-        <translation type="unfinished"></translation>
+        <translation>Product code</translation>
     </message>
 </context>
 <context>
@@ -14171,57 +14323,57 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="25"/>
         <source>Käyttöliittymä</source>
-        <translation type="unfinished"></translation>
+        <translation>User interface</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="32"/>
         <source>Kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="38"/>
         <source>suomi</source>
-        <translation type="unfinished"></translation>
+        <translation>Finnish</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="49"/>
         <source>ruotsi</source>
-        <translation type="unfinished"></translation>
+        <translation>Swedish</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="63"/>
         <source>Tilikartan kieli</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts language</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="75"/>
         <source>Kirjasin</source>
-        <translation type="unfinished"></translation>
+        <translation>Font</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="81"/>
         <source>Järjestelmän oletuskirjasin</source>
-        <translation type="unfinished"></translation>
+        <translation>System default font</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="93"/>
         <source>Omavalintainen</source>
-        <translation type="unfinished"></translation>
+        <translation>Custom</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="125"/>
         <source>Saldonäkymä</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance view</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.ui" line="136"/>
         <source>Nopeampi pdf-tiedostojen esittäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Faster PDF file presentation</translation>
     </message>
 </context>
 <context>
@@ -14229,12 +14381,12 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../maaritys/ulkoasumaaritys.cpp" line="121"/>
         <source>Kieli vaihdettu</source>
-        <translation type="unfinished"></translation>
+        <translation>Language changed</translation>
     </message>
     <message>
         <location filename="../maaritys/ulkoasumaaritys.cpp" line="122"/>
         <source>Käynnistä kielen vaihtamisen jälkeen ohjelma uudelleen, jotta valitsemasi kieli tulee käyttöön kaikissa näkymissä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Restart the program after changing the language to apply the selected language in all views.</translation>
     </message>
 </context>
 <context>
@@ -14242,42 +14394,42 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../arkisto/uudelleennumerointi.ui" line="14"/>
         <source>Uudelleennumerointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Renumbering</translation>
     </message>
     <message>
         <location filename="../arkisto/uudelleennumerointi.ui" line="20"/>
         <source>Toiminto numeroi  tositteet uudelleen aikajärjestykseen.</source>
-        <translation type="unfinished"></translation>
+        <translation>This function renumbers the vouchers in chronological order.</translation>
     </message>
     <message>
         <location filename="../arkisto/uudelleennumerointi.ui" line="45"/>
         <source>Tositteiden numerointi muuttuu ja paperiset tositteet pitää merkitä uudelleen uusilla tositenumeroilla</source>
-        <translation type="unfinished"></translation>
+        <translation>The numbering of vouchers changes and paper vouchers need to be marked again with new voucher numbers</translation>
     </message>
     <message>
         <location filename="../arkisto/uudelleennumerointi.ui" line="57"/>
         <source>Uudelleennumeroinnin aikaväli</source>
-        <translation type="unfinished"></translation>
+        <translation>Renumbering time interval</translation>
     </message>
     <message>
         <location filename="../arkisto/uudelleennumerointi.ui" line="63"/>
         <source>Alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Starts</translation>
     </message>
     <message>
         <location filename="../arkisto/uudelleennumerointi.ui" line="76"/>
         <source>Päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>Ends</translation>
     </message>
     <message>
         <location filename="../arkisto/uudelleennumerointi.ui" line="92"/>
         <source>Tiliote kauden alussa</source>
-        <translation type="unfinished"></translation>
+        <translation>Account statement at the beginning of the period</translation>
     </message>
     <message>
         <location filename="../arkisto/uudelleennumerointi.cpp" line="66"/>
         <source>Tositteet numeroitu uudelleen</source>
-        <translation type="unfinished"></translation>
+        <translation>Vouchers renumbered</translation>
     </message>
 </context>
 <context>
@@ -14285,32 +14437,32 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusialkusivu.cpp" line="31"/>
         <source>Tervetuloa!</source>
-        <translation type="unfinished"></translation>
+        <translation>Welcome!</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialkusivu.cpp" line="58"/>
         <source>Käyttääksesi pilveä luo ensin käyttäjätunnus tai kirjaudu sisään.</source>
-        <translation type="unfinished"></translation>
+        <translation>To use the cloud, first create a user account or log in.</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialkusivu.cpp" line="64"/>
         <source>Luodaksesi enemmän kirjanpitoja pilveen sinun on ensin tehtävä Kitsaan tilaus.</source>
-        <translation type="unfinished"></translation>
+        <translation>To create more cloud-based bookkeeping records, you need to subscribe to Kitsas first.</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialkusivu.cpp" line="68"/>
         <source>Maksuttoman kokeilujaksosi ajan sinulla voi olla yksi pilveen tallennettu kirjanpito. Ellet tee maksullista tilausta, poistetaan tämä kirjanpito kokeilujaksosi päätyttyä.</source>
-        <translation type="unfinished"></translation>
+        <translation>During your free trial period, you can have one cloud-stored bookkeeping record. If you don&apos;t make a paid subscription, this record will be deleted after your trial period ends.</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialkusivu.cpp" line="71"/>
         <source>Päivitä tilauksesi</source>
-        <translation type="unfinished"></translation>
+        <translation>Update your subscription</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialkusivu.cpp" line="62"/>
         <source>Kirjanpidon tallentamisesta pilveen veloitetaan %1/kk</source>
-        <translation type="unfinished"></translation>
+        <translation>Cloud storage for bookkeeping is charged at %1/month</translation>
     </message>
 </context>
 <context>
@@ -14318,42 +14470,42 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kitsas on avoimen lähdekoodin helppokäyttöinen kirjanpito-ohjelma. Ohjelma neuvoo sinua niin kirjanpitoa aloitettaessa kuin myös myöhemmissä vaiheissa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kitsas is an open-source, user-friendly accounting program. The program guides you both when starting your bookkeeping and in later stages.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="42"/>
         <source>Tallenna kirjanpito omalle tietokoneelle</source>
-        <translation type="unfinished"></translation>
+        <translation>Save bookkeeping on your own computer</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="53"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kirjanpito tallennetaan oman tietokoneesi levylle. Kirjanpitoa voi käyttää vain tältä tietokoneelta, ja sinun pitää huolehtia itse kirjanpitosi varmuuskopioinnista. Voit käyttää ohjelmaa omalla koneella täysin maksutta.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The bookkeeping is saved on your own computer&apos;s drive. You can only use the bookkeeping from this computer, and you need to take care of backing up your bookkeeping yourself. You can use the program on your own computer completely free of charge.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="69"/>
         <source>Tallenna kirjanpito pilveen</source>
-        <translation type="unfinished"></translation>
+        <translation>Save bookkeeping to the cloud</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="80"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kirjanpito tallennetaan pilveen suomalaiselle palvelimelle. Kirjanpidolla voi olla useampi samanaikainen käyttäjä. Kitsas Oy huolehtii kirjanpidon päivittäisestä varmuuskopioinnista.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The bookkeeping is saved to the cloud on a Finnish server. The bookkeeping can have multiple simultaneous users. Kitsas Oy takes care of daily backups of the bookkeeping.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="97"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p/&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p/&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialoitus.ui" line="122"/>
         <source>Tilaa pilvipalvelu</source>
-        <translation type="unfinished"></translation>
+        <translation>Subscribe to cloud service</translation>
     </message>
 </context>
 <context>
@@ -14361,17 +14513,17 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusialustus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialustus.ui" line="30"/>
         <source>Tervetuloa aloittamaan uutta kirjanpitoa </source>
-        <translation type="unfinished"></translation>
+        <translation>Welcome to start a new bookkeeping </translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusialustus.ui" line="45"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
 </context>
 <context>
@@ -14379,32 +14531,32 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusiharjoitus.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiharjoitus.ui" line="20"/>
         <source>Onko luotava kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Is the bookkeeping to be created</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiharjoitus.ui" line="31"/>
         <source>Harjoitus tai kokeilu</source>
-        <translation type="unfinished"></translation>
+        <translation>Practice or trial</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiharjoitus.ui" line="41"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voit kokeilla kaikki ohjelman ominaisuuksia. Voit nopeuttaa ajan kulumista niin, että pääset tekemään myös tilinpäätöksen ja aloittamaan uuden tilivuoden. Kaikissa tulosteissa näkyy, että käytät ohjelmaa harjoittelutilassa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can try all the features of the program. You can speed up the passage of time so that you can also make financial statements and start a new accounting period. All printouts show that you are using the program in practice mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiharjoitus.ui" line="56"/>
         <source>Todellinen kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Real accounting</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiharjoitus.ui" line="63"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Olet ryhtymässä varsinaiseen kirjanpitolain mukaiseen kirjanpitoon. Vaikka ohjelma opastaa eri vaiheissa, on kirjanpidon osaaminen kuitenkin tarpeen. Suositeltavaa on myös kokeilla ohjelmaa ensin harjoitustilassa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You are about to start actual accounting in accordance with the accounting law. Although the program guides you through different stages, accounting knowledge is still necessary. It is also recommended to try the program first in practice mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -14412,22 +14564,22 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../liite/uusiliitewidget.cpp" line="61"/>
         <source>Valitse tosite</source>
-        <translation type="unfinished"></translation>
+        <translation>Select voucher</translation>
     </message>
     <message>
         <location filename="../liite/uusiliitewidget.cpp" line="61"/>
         <source>Pdf-tiedostot (*.pdf);;Kuvat (*.png *.jpg);;Csv-tiedosto (*.csv);;Kaikki tiedostot (*)</source>
-        <translation type="unfinished"></translation>
+        <translation>PDF files (*.pdf);;Images (*.png *.jpg);;CSV file (*.csv);;All files (*)</translation>
     </message>
     <message>
         <location filename="../liite/uusiliitewidget.cpp" line="76"/>
         <source>liite.jpg</source>
-        <translation type="unfinished"></translation>
+        <translation>attachment.jpg</translation>
     </message>
     <message>
         <location filename="../liite/uusiliitewidget.cpp" line="78"/>
         <source>liite.png</source>
-        <translation type="unfinished"></translation>
+        <translation>attachment.png</translation>
     </message>
 </context>
 <context>
@@ -14435,22 +14587,22 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusiloppu.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiloppu.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kitsas on nyt valmis luomaan uuden kirjanpidon.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kitsas is now ready to create a new accounting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiloppu.ui" line="30"/>
         <source>Kirjanpitosi tallennetaan Kitsas Oy:n Suomessa sijaitsevalle palvelimelle. Kaiken varalta kirjanpitosi varmuuskopioidaan joka päivä. Pääset kirjanpitoosi, kun olet kirjautunut Kitsaan käyttäjätunnuksellasi ja sinulla on toimiva nettiyhteys.</source>
-        <translation type="unfinished"></translation>
+        <translation>Your accounting will be saved on Kitsas Oy&apos;s server located in Finland. As a precaution, your accounting is backed up every day. You can access your accounting when you have logged in with your Kitsas username and have a working internet connection.</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusiloppu.ui" line="44"/>
         <source>x</source>
-        <translation type="unfinished"></translation>
+        <translation>x</translation>
     </message>
 </context>
 <context>
@@ -14458,12 +14610,12 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../laskutus/laskudlg/uusimaksumuistutusdialogi.cpp" line="246"/>
         <source>Maksumuistutuksen tallentaminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Saving the payment reminder failed</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/uusimaksumuistutusdialogi.cpp" line="246"/>
         <source>Maksumuistuksen muodostaminen epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating the payment reminder failed.</translation>
     </message>
 </context>
 <context>
@@ -14471,27 +14623,27 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/numerointi.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/numerointi.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kirjanpidon tositteet voi jakaa eri tositesarjoihin, kuten myyntilaskuihin, ostolaskuihin ja tiliotteisiin.&lt;/p&gt;&lt;p&gt;Haluatko, että kaikki tositteet numeroidaan samaan juoksevaan sarjaan, vai että eri tositelajit numeroidaan jokainen omaan tositesarjaansa?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Accounting vouchers can be divided into different voucher series, such as sales invoices, purchase invoices, and bank statements.&lt;/p&gt;&lt;p&gt;Do you want all vouchers to be numbered in the same sequential series, or do you want different voucher types to be numbered in their own separate series?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/numerointi.ui" line="36"/>
         <source>Numeroi kaikki tositteet samaan juoksevaan numerosarjaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Number all vouchers in the same sequential number series</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/numerointi.ui" line="50"/>
         <source>Numeroi jokainen tositelaji omaan numerosarjaansa</source>
-        <translation type="unfinished"></translation>
+        <translation>Number each voucher type in its own number series</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/numerointi.ui" line="64"/>
         <source>Käytä käteistositteille omaa numerosarjaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Use a separate number series for cash vouchers</translation>
     </message>
 </context>
 <context>
@@ -14499,37 +14651,37 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusisijainti.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusisijainti.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Valitse, minne kirjanpitosi tallennetaan.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose where your accounting will be saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusisijainti.ui" line="34"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Huolehdi kirjanpitosi varmuuskopioinnista.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Varmuuskopioi kirjanpitosi säännöllisesti ja säilytä varmuuskopiota turvallisessa paikassa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Take care of backing up your accounting.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Back up your accounting regularly and store the backup in a safe place.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusisijainti.ui" line="44"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Jos kirjanpitosi sisältää henkilötietoja, huomioi EU:n tietosuojalainsäädäntö tietojen tallentamisessa ja käsittelyssä. Tällaista tiedostoa ei pääsääntöisesti saa tallentaa pilvipalveluun, joka sijaitsee ETA-alueen ulkopuolella.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your accounting contains personal data, consider the EU data protection legislation in storing and processing the data. As a general rule, such a file should not be stored in a cloud service located outside the EEA area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusisijainti.ui" line="56"/>
         <source>Tiedostonnimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Filename</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusisijainti.ui" line="69"/>
         <source>Sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>Location</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusisijainti.ui" line="88"/>
         <source>Vaihda</source>
-        <translation type="unfinished"></translation>
+        <translation>Change</translation>
     </message>
 </context>
 <context>
@@ -14537,77 +14689,77 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="20"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="33"/>
         <source>Katuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Street address</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="56"/>
         <source>Pankkitili (IBAN)</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank account (IBAN)</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="66"/>
         <source>FI0000000000000000</source>
-        <translation type="unfinished"></translation>
+        <translation>FI0000000000000000</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="73"/>
         <source>Yritysmuoto</source>
-        <translation type="unfinished"></translation>
+        <translation>Company form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="86"/>
         <source>Tilikartan laajuus</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts scope</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="112"/>
         <source>Y-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Business ID</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="129"/>
         <source>Kotipaikka</source>
-        <translation type="unfinished"></translation>
+        <translation>Domicile</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="139"/>
         <source>Postiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Postal address</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="160"/>
         <source>Sähköpostiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Email address</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="167"/>
         <source>Kotisivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Homepage</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="180"/>
         <source>Puhelinnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="190"/>
         <source>BIC</source>
-        <translation type="unfinished"></translation>
+        <translation>BIC</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitiedot.ui" line="197"/>
         <source>Pankki</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank</translation>
     </message>
 </context>
 <context>
@@ -14615,37 +14767,37 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusitilikartta.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitilikartta.ui" line="20"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Valitse käytettävä tilikartta kirjanpidosi mukaisesti. Voit myöhemmin muokata käyttöön otettavaa mallitilikarttaa ja raporttipohjia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Valitse käytettävä tilikartta kirjanpitosi mukaisesti. Voit myöhemmin muokata käyttöön otettavaa mallitilikarttaa ja raporttipohjia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the chart of accounts to be used according to your bookkeeping. You can later modify the model chart of accounts and report templates that will be implemented.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitilikartta.ui" line="45"/>
         <source>Elinkeinotoiminta</source>
-        <translation type="unfinished"></translation>
+        <translation>Business activity</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitilikartta.ui" line="58"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Osakeyhtiö, osuuskunta, kommandiittiyhtiö, avoin yhtiö sekä ammatin- ja elinkeinonharjoittaja (toiminimi).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limited company, cooperative, limited partnership, general partnership, and sole trader (trade name).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitilikartta.ui" line="74"/>
         <source>Aatteellinen yhdistys tai säätiö</source>
-        <translation type="unfinished"></translation>
+        <translation>Non-profit association or foundation</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitilikartta.ui" line="90"/>
         <source>Asunto-osakeyhtiö</source>
-        <translation type="unfinished"></translation>
+        <translation>Housing company</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusitilikartta.ui" line="128"/>
         <source>Käytä tilikarttatiedostoa...</source>
-        <translation type="unfinished"></translation>
+        <translation>Use chart of accounts file...</translation>
     </message>
 </context>
 <context>
@@ -14653,32 +14805,32 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../arkisto/lisaatilikausidlg.ui" line="14"/>
         <source>Lisää uusi tilikausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Add new accounting period</translation>
     </message>
     <message>
         <location filename="../arkisto/lisaatilikausidlg.ui" line="20"/>
         <source>Lisää tilikausi alkuun</source>
-        <translation type="unfinished"></translation>
+        <translation>Add accounting period to the beginning</translation>
     </message>
     <message>
         <location filename="../arkisto/lisaatilikausidlg.ui" line="27"/>
         <source>Lisää tilikausi loppuun</source>
-        <translation type="unfinished"></translation>
+        <translation>Add accounting period to the end</translation>
     </message>
     <message>
         <location filename="../arkisto/lisaatilikausidlg.ui" line="39"/>
         <source>Tilikausi alkaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period begins</translation>
     </message>
     <message>
         <location filename="../arkisto/lisaatilikausidlg.ui" line="56"/>
         <source>Tilikausi päättyy</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period ends</translation>
     </message>
     <message>
         <location filename="../arkisto/lisaatilikausidlg.ui" line="71"/>
         <source>Tilikausi on tilinavaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting period is opening balance</translation>
     </message>
 </context>
 <context>
@@ -14687,63 +14839,63 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
         <location filename="../uusikirjanpito/uusivelho.cpp" line="96"/>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="104"/>
         <source>Tilikartan lukeminen epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to read chart of accounts</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="97"/>
         <source>Virheellinen tilikarttatiedosto</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid chart of accounts file</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="104"/>
         <source>Tilikarttatiedostoa %1 ei voi avata</source>
-        <translation type="unfinished"></translation>
+        <translation>Cannot open chart of accounts file %1</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="285"/>
         <source>Harjoitus vai todellinen?</source>
-        <translation type="unfinished"></translation>
+        <translation>Practice or real?</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="298"/>
         <source>Tilikartta</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="319"/>
         <source>Valitse tilikarttatiedoston</source>
-        <translation type="unfinished"></translation>
+        <translation>Select the chart of accounts file</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="320"/>
         <source>Kitsaan tilikartta (*.kitsaskartta)</source>
         <comment>.kitsaskartta on tiedostopääte - älä käännä sitä</comment>
-        <translation type="unfinished"></translation>
+        <translation>Kitsas chart of accounts (*.kitsaskartta)</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="362"/>
         <source>&lt;p&gt;Kirjanpitosi tallennetaan tietokoneellesi hakemistoon &lt;tt&gt;%1&lt;/tt&gt; tiedostoon &lt;tt&gt;%2&lt;/tt&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Muista tiedostosi sijainti&lt;/b&gt;, jotta pystyt avaamaan sen myöhemmin.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Huolehdi jatkuvasti tämän tiedoston varmuuskopioinnista!&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;p&gt;Your accounting will be saved on your computer in the directory &lt;tt&gt;%1&lt;/tt&gt; to the file &lt;tt&gt;%2&lt;/tt&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Remember the location of your file&lt;/b&gt; so that you can open it later.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Always make sure to back up this file!&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="334"/>
         <source>Tositteiden numerointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Numbering of vouchers</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="343"/>
         <source>Huolehdi kirjanpitosi varmuuskopioinnista</source>
-        <translation type="unfinished"></translation>
+        <translation>Take care of backing up your accounting</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="350"/>
         <source>Vastuu kirjanpidosta</source>
-        <translation type="unfinished"></translation>
+        <translation>Responsibility for accounting</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivelho.cpp" line="357"/>
         <source>Valmis</source>
-        <translation type="unfinished"></translation>
+        <translation>Ready</translation>
     </message>
 </context>
 <context>
@@ -14751,12 +14903,12 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../uusikirjanpito/uusivastuu.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/uusivastuu.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Olet itse vastuussa kirjanpitosi oikeellisuudesta ja laillisuudesta sekä siitä, että kaikki verot maksetaan asianmukaisesti.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Ohjelmalla ei ole mitään takuuta.&lt;/span&gt; Kitsas Oy ei myöskään anna oikeudellista neuvontaa kirjanpidosta tai verotuksesta.&lt;/p&gt;&lt;p&gt;Käänny tarvittaessa kirjanpidon ammattilaisen puoleen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You are responsible for the accuracy and legality of your accounting and for ensuring that all taxes are paid properly.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The program comes with no warranty.&lt;/span&gt; Kitsas Oy also does not provide legal advice on accounting or taxation.&lt;/p&gt;&lt;p&gt;If necessary, consult an accounting professional.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -14764,52 +14916,52 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="14"/>
         <source>Vakioviite</source>
-        <translation type="unfinished"></translation>
+        <translation>Standard reference</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="20"/>
         <source>Vakioviitteellä voit automatisoida saapuvan viitemaksun tiliöinnin.</source>
-        <translation type="unfinished"></translation>
+        <translation>With a standard reference, you can automate the accounting of incoming reference payments.</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="30"/>
         <source>Numerointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Numbering</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="36"/>
         <source>Seuraava viitenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Next reference number</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="46"/>
         <source>Valitse numero itse</source>
-        <translation type="unfinished"></translation>
+        <translation>Choose the number yourself</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="61"/>
         <source>Viitenumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference number</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="87"/>
         <source>Viitenumero on jo käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference number is already in use</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="96"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="109"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitedlg.ui" line="122"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
 </context>
 <context>
@@ -14817,22 +14969,22 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
     <message>
         <location filename="../laskutus/vakioviite/vakioviitemodel.cpp" line="30"/>
         <source>Viite</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitemodel.cpp" line="31"/>
         <source>Tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Account</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitemodel.cpp" line="32"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../laskutus/vakioviite/vakioviitemodel.cpp" line="33"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
 </context>
 <context>
@@ -14842,173 +14994,179 @@ Säilytä veroilmoitus ja mahdolliset verolaskelmasi kirjanpitosi yhteydessä.</
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="306"/>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="309"/>
         <source>Kirjanpidon tuonti</source>
-        <translation type="unfinished"></translation>
+        <translation>Accounting import</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="29"/>
         <source>Kirjanpidon tuonti Kitupiikistä</source>
-        <translation type="unfinished"></translation>
+        <translation>Import bookkeeping from Kitupiikki</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="43"/>
         <source>Valitse tuotava kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Select accounting to import</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="55"/>
         <source>Valitse tiedosto</source>
-        <translation type="unfinished"></translation>
+        <translation>Select file</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="72"/>
         <source>Avataan tiedostoa ...</source>
-        <translation type="unfinished"></translation>
+        <translation>Opening file ...</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="103"/>
         <source>Olet muokannut raportteja tai tilinpäätöksen mallia. Siirretyssä kirjanpidossa käytetään kuitenkin Kitsaan oletusraportteja ja -tilinpäätöstä, ja mahdolliset tarvittavat muokkaukset on tehtävä uudestaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>You have modified reports or the financial statement template. However, the transferred accounting uses Kitsas default reports and financial statements, and any necessary modifications need to be made again.</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="119"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;font color=red&gt;Kirjanpidossa on maksamattomia maksuperusteisia laskuja. Näitä laskuja ei tuoda uuteen kirjanpitoon.&lt;/font&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;font color=red&gt;There are unpaid cash-based invoices in the accounting. These invoices will not be imported into the new accounting.&lt;/font&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="133"/>
         <source>Organisaation nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Organization name</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="146"/>
         <source>Tilikartta</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="153"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="160"/>
         <source>Tilikartan laajuus</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts scope</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="176"/>
         <source>Säilytä tositteiden numerointi</source>
-        <translation type="unfinished"></translation>
+        <translation>Preserve voucher numbering</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="186"/>
         <source>Tuo asiakasluettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>Import customer list</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="200"/>
         <source>Minne uusi Kitsaan kirjanpito tallennetaan?</source>
-        <translation type="unfinished"></translation>
+        <translation>Where will the new Kitsas accounting be saved?</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="207"/>
         <source>Muista huolehtia kirjanpitotiedoston varmuuskopioinnista!</source>
-        <translation type="unfinished"></translation>
+        <translation>Remember to take care of backing up the accounting file!</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="216"/>
         <source>Tiedoston nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>File name</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="231"/>
         <source>.kitsas</source>
-        <translation type="unfinished"></translation>
+        <translation>.kitsas</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="240"/>
         <source>Tiedoston sijainti</source>
-        <translation type="unfinished"></translation>
+        <translation>File location</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="259"/>
         <source>Vaihda</source>
-        <translation type="unfinished"></translation>
+        <translation>Change</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="304"/>
         <source>Kirjanpitoa tuodaan....</source>
-        <translation type="unfinished"></translation>
+        <translation>Importing accounting....</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="335"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kirjanpidon tuonti on valmis.&lt;/p&gt;&lt;p&gt;Kirjanpito on tuotu uudeksi Kitsaalle sopivaksi tiedostoksi. Kitupiikin tiedosto on edelleen jäljellä vanhassa muodossa. Kitsaassa tehdyt muutokset eivät vaikuta Kitupiikin tiedostoon.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#000000;&quot;&gt;Tarkasta Kitsaaseen siirretty kirjanpito sekä asetukset ennen kuin alat käyttää siirrettyä kirjanpitoa.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The accounting import is complete.&lt;/p&gt;&lt;p&gt;The accounting has been imported as a new file suitable for Kitsas. The Kitupiikki file still remains in its old format. Changes made in Kitsas do not affect the Kitupiikki file.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#000000;&quot;&gt;Check the accounting transferred to Kitsas and the settings before you start using the transferred accounting.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="349"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Kirjanpidon tuonti onnistui vain osittain&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Kaikkien tositteiden tuonti ei ole onnistunut, ja taseen loppusumma tuodussa kirjanpidossa poikkeaa alkuperäisestä kirjanpidosta.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Useimmiten virhe johtuu siitä, että Kitupiikin kirjanpito on jo päivitetty monta kertaa uudempaan versioon, ja jossain aiemmassa päivityksessä on ollut puutteita.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Alkuperäinen Kitupiikin kirjanpito on edelleen käytössä. Ota siirretty uusi kirjanpito käyttöösi vain, jos voit täydentää sen virheettömäksi. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;Kitsaan käyttöön kannattaa ehkä siirtyä vasta tilikauden vaihtuessa niin, että vanha tilikausi ja tilinpäätös tehdään loppuun saakka Kitupiikillä, ja vasta uusi tilikausi aloitetaan Kitsaalla. Muista tehdä Kitsaassa tilinavaus Kitupiikin tilinpäätöksen pohjalta.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;The accounting import was only partially successful&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Not all vouchers were successfully imported, and the balance sheet total in the imported accounting differs from the original accounting.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Most often, the error is due to the fact that the Kitupiikki accounting has already been updated many times to a newer version, and there have been deficiencies in some previous updates.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;The original Kitupiikki accounting is still in use. Only use the transferred new accounting if you can complete it without errors. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;It might be advisable to switch to using Kitsas only when changing the accounting period, so that the old accounting period and financial statements are completed with Kitupiikki, and only the new accounting period is started with Kitsas. Remember to make an opening entry in Kitsas based on Kitupiikki&apos;s financial statements.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="378"/>
         <source>Ohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="402"/>
         <source>Jatka</source>
-        <translation type="unfinished"></translation>
+        <translation>Continue</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="409"/>
         <source>Tuo kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>Import bookkeeping</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.ui" line="420"/>
         <source>Sulje</source>
-        <translation type="unfinished"></translation>
+        <translation>Close</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="103"/>
         <source>Valitse tuotava kirjanpitotiedosto</source>
-        <translation type="unfinished"></translation>
+        <translation>Select bookkeeping file to import</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="151"/>
         <source>Valitsemaasi tiedostoa %1 ei voi avata, tai se ei ole SQLITE-tietokanta.
 
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>The selected file %1 cannot be opened, or it is not an SQLITE database.
+
+%2</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="166"/>
         <source>Tiedoston %1 avaamisessa tapahtui virhe tai valitsemasi tiedosto ei ole Kitupiikin tietokanta 
 
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>An error occurred while opening file %1 or the selected file is not a Kitupiikki database 
+
+%2</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="180"/>
         <source>Valitsemasi tiedosto ei ole Kitupiikin kirjanpito.</source>
-        <translation type="unfinished"></translation>
+        <translation>The selected file is not a Kitupiikki bookkeeping.</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="182"/>
         <source>Valitsemasi tiedosto on jo Kitsaan kirjanpito</source>
-        <translation type="unfinished"></translation>
+        <translation>The selected file is already a Kitsas bookkeeping</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="163"/>
         <source>Valitsemaasi tietokantaa ei voi avata, koska se on toisen ohjelman käytössä.</source>
-        <translation type="unfinished"></translation>
+        <translation>The selected database cannot be opened because it is in use by another program.</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="184"/>
         <source>Valitsemaasi tiedosto on tallennettu vanhalla Kitupiikin versiolla.
 
 Tiedosto on ensin avattava uudemmalla Kitupiikin versiolla, jotta se päivittyy uudempaan tiedostomuotoon</source>
-        <translation type="unfinished"></translation>
+        <translation>The selected file is saved with an old version of Kitupiikki.
+
+The file must first be opened with a newer version of Kitupiikki to update it to a newer file format</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="190"/>
@@ -15017,43 +15175,47 @@ Tiedosto on ensin avattava uudemmalla Kitupiikin versiolla, jotta se päivittyy 
 Tuontitoiminto tukee ainoastaa uusimpia elinkeinotoiminnan, yhdistyksen ja asunto-osakeyhtiön tilikarttoja.
 
 Kirjanpidot, jotka on aloitettu Kitupiikin vanhimmilla versioilla, voi siirtää Kitsaaseen ainoastaan luomalla uuden kirjanpidon ja tekemällä siihen tilinavauksen vanhan kirjanpidon pohjalta.</source>
-        <translation type="unfinished"></translation>
+        <translation>The import function does not support your chart of accounts type %1 (%2).
+
+The import function only supports the latest charts of accounts for business, association, and housing company.
+
+Bookkeepings started with the oldest versions of Kitupiikki can only be transferred to Kitsas by creating a new bookkeeping and making an opening balance based on the old bookkeeping.</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="228"/>
         <source>Yhdistys</source>
-        <translation type="unfinished"></translation>
+        <translation>Association</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="250"/>
         <source>Yritys (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Company (%1)</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="253"/>
         <source>Asunto-osakeyhtiö</source>
-        <translation type="unfinished"></translation>
+        <translation>Housing company</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="295"/>
         <source>Valitse tallennushakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Select save directory</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="306"/>
         <source>Tiedoston nimi ei kelpaa</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid file name</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="309"/>
         <source>Tiedosto %1 on jo olemassa.</source>
-        <translation type="unfinished"></translation>
+        <translation>File %1 already exists.</translation>
     </message>
     <message>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="351"/>
         <location filename="../kitupiikkituonti/vanhatuontidlg.cpp" line="359"/>
         <source>Uuden tietokannan luominen epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to create new database.</translation>
     </message>
 </context>
 <context>
@@ -15061,7 +15223,7 @@ Kirjanpidot, jotka on aloitettu Kitupiikin vanhimmilla versioilla, voi siirtää
     <message>
         <location filename="../tools/varinvalinta.cpp" line="36"/>
         <source>Valitse väri</source>
-        <translation type="unfinished"></translation>
+        <translation>Select a color</translation>
     </message>
 </context>
 <context>
@@ -15069,22 +15231,22 @@ Kirjanpidot, jotka on aloitettu Kitupiikin vanhimmilla versioilla, voi siirtää
     <message>
         <location filename="../alv/varmennedialog.ui" line="14"/>
         <source>Uusi varmenne</source>
-        <translation type="unfinished"></translation>
+        <translation>New certificate</translation>
     </message>
     <message>
         <location filename="../alv/varmennedialog.ui" line="20"/>
         <source>Anna turvasähköpostissa saamasi tunnisteet</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter the identifiers you received in the secure email</translation>
     </message>
     <message>
         <location filename="../alv/varmennedialog.ui" line="29"/>
         <source>Siirtotunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Transfer ID</translation>
     </message>
     <message>
         <location filename="../alv/varmennedialog.ui" line="42"/>
         <source>Kertakäyttösalasana</source>
-        <translation type="unfinished"></translation>
+        <translation>One-time password</translation>
     </message>
 </context>
 <context>
@@ -15092,12 +15254,12 @@ Kirjanpidot, jotka on aloitettu Kitupiikin vanhimmilla versioilla, voi siirtää
     <message>
         <location filename="../uusikirjanpito/varmista.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../uusikirjanpito/varmista.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Olet valinnut, että kirjanpitosi tallennetaan omalla tietokoneellasi olevaan tiedostoon.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Huolehdi tämän tiedoston varmuuskopioinnista. &lt;/span&gt;Jos tietokoneellasi oleva tiedosto vahingoittuu, saattaa kaikki kirjanpidon parissa tekemäsi työ tuhoutua pysyvästi. &lt;/p&gt;&lt;p&gt;Pidä varmuuskopiosi jatkuvasti ajan tasalla ja säilytä niitä turvallisessa paikassa niin, että ne ovat käytettävissä, vaikka kaikki omalla tietokoneellasi olevat tiedot häviäisivät.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You have chosen to save your accounting in a file on your own computer.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Make sure to back up this file. &lt;/span&gt;If the file on your computer gets damaged, all the work you&apos;ve done on your accounting may be permanently lost. &lt;/p&gt;&lt;p&gt;Keep your backups up-to-date and store them in a safe place so that they are available even if all the data on your own computer is lost.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -15105,67 +15267,67 @@ Kirjanpidot, jotka on aloitettu Kitupiikin vanhimmilla versioilla, voi siirtää
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="14"/>
         <source>Kuukausittaiset laskut</source>
-        <translation type="unfinished"></translation>
+        <translation>Monthly invoices</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="26"/>
         <source>Laskutusjakso</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing period</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="41"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation>-</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="53"/>
         <source>Eräpäivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Due date</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="63"/>
         <source>. päivä</source>
-        <translation type="unfinished"></translation>
+        <translation>th day</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="66"/>
         <source>kuukauden </source>
-        <translation type="unfinished"></translation>
+        <translation>of the month </translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="82"/>
         <source>Laskun pvm</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice date</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="95"/>
         <source>Otsikko</source>
-        <translation type="unfinished"></translation>
+        <translation>Title</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="108"/>
         <source>Lisätiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Additional information</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.ui" line="121"/>
         <source>Saate</source>
-        <translation type="unfinished"></translation>
+        <translation>Cover letter</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.cpp" line="48"/>
         <source>Luodaan laskuja</source>
-        <translation type="unfinished"></translation>
+        <translation>Creating invoices</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.cpp" line="49"/>
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
         <location filename="../laskutus/huoneisto/vastikelaskutus.cpp" line="63"/>
         <source>Uudet laskut löytyvät Lähetettävät-välilehdeltä.</source>
-        <translation type="unfinished"></translation>
+        <translation>New invoices can be found on the To Be Sent tab.</translation>
     </message>
 </context>
 <context>
@@ -15173,122 +15335,122 @@ Kirjanpidot, jotka on aloitettu Kitupiikin vanhimmilla versioilla, voi siirtää
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="169"/>
         <source>Valitse laskujen tallennushakemisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Select invoice save directory</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="82"/>
         <source>Puutteelliset määritykset</source>
-        <translation type="unfinished"></translation>
+        <translation>Incomplete settings</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="83"/>
         <source>Verkkolaskutuksen määritykset ovat puutteelliset.</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoicing settings are incomplete.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="260"/>
         <source>Yritykselläsi ei ole vielä Maventan verkkolaskutiliä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Your company does not yet have a Maventa e-invoicing account.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="262"/>
         <source>Yritykselläsi on jo Maventan verkkolaskutili</source>
-        <translation type="unfinished"></translation>
+        <translation>Your company already has Maventa&apos;s e-invoicing account</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="274"/>
         <source>Käyttöönottoon tarvittava allekirjoituspyyntö lähetetään pian sähköpostiosoitteeseen %1</source>
-        <translation type="unfinished"></translation>
+        <translation>The signature request needed for activation will be sent soon to the email address %1</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="276"/>
         <source>Käyttöönottoon tarvittava allekirjoituspyyntö on lähetetty sähköpostiosoitteeseen %1</source>
-        <translation type="unfinished"></translation>
+        <translation>The signature request needed for activation has been sent to the email address %1</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="278"/>
         <source>Sähköinen allekirjoituspyyntö on peruttu</source>
-        <translation type="unfinished"></translation>
+        <translation>The electronic signature request has been canceled</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="280"/>
         <source>Käyttöönottoa ei ole vahvistettu sähköisellä allekirjoituksella</source>
-        <translation type="unfinished"></translation>
+        <translation>The activation has not been confirmed with an electronic signature</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="282"/>
         <source>Verkkolaskuosoitteen rekisteröinnissä on tapahtunut virhe.</source>
-        <translation type="unfinished"></translation>
+        <translation>An error occurred while registering the e-invoice address.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="284"/>
         <source>Verkkolaskuosoitteesi rekisteröinti on kesken.</source>
-        <translation type="unfinished"></translation>
+        <translation>The registration of your e-invoice address is in progress.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="286"/>
         <source>Verkkolaskujen vastaanottoa ei ole otettu käyttöön.</source>
-        <translation type="unfinished"></translation>
+        <translation>The reception of e-invoices has not been activated.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="288"/>
         <source>Pankkiyhteyden käyttöönotossa on tapahtunut virhe.</source>
-        <translation type="unfinished"></translation>
+        <translation>An error occurred during the activation of the bank connection.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="290"/>
         <source>Pankkiyhteyden käyttöönotto on kesken. Tämä voi kestää muutaman arkipäivän.</source>
-        <translation type="unfinished"></translation>
+        <translation>The activation of the bank connection is in progress. This may take a few business days.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="292"/>
         <source>Pankkiyhteyttä ei ole otettu käyttöön.</source>
-        <translation type="unfinished"></translation>
+        <translation>The bank connection has not been activated.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="294"/>
         <source>Kansainvälisen PEPPOL-yhteyden käyttöönotossa on tapahtunut virhe.</source>
-        <translation type="unfinished"></translation>
+        <translation>An error occurred during the activation of the international PEPPOL connection.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="296"/>
         <source>Kansainvälisen PEPPOL-yhteyden käyttöönotto on kesken.</source>
-        <translation type="unfinished"></translation>
+        <translation>The activation of the international PEPPOL connection is in progress.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="298"/>
         <source>Kansainvälistä PEPPOL-yhteyttä ei ole otettu käyttöön.</source>
-        <translation type="unfinished"></translation>
+        <translation>The international PEPPOL connection has not been activated.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="309"/>
         <source>Verkkolaskujen hinnoittelu Kitsaan hinnaston mukaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice pricing according to Kitsas pricing list.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="309"/>
         <source>Verkkolaskujen hinnoittelu Maventan hinnaston mukaan.</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice pricing according to Maventa pricing list.</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="310"/>
         <source>Verkkolaskujen nouto on käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>E-invoice retrieval is enabled</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="310"/>
         <source>Verkkolaskujen automaattista noutoa ei ole otettu käyttöön</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatic retrieval of e-invoices has not been enabled</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="311"/>
         <source>Postitettavien laskujen tulostus ja postitus Maventan kautta käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Printing and mailing of invoices through Maventa is enabled</translation>
     </message>
     <message>
         <location filename="../maaritys/verkkolasku/verkkolaskumaaritys.cpp" line="311"/>
         <source>Tulostuspalvelu ei ole käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Printing service is not enabled</translation>
     </message>
 </context>
 <context>
@@ -15296,164 +15458,165 @@ Kirjanpidot, jotka on aloitettu Kitupiikin vanhimmilla versioilla, voi siirtää
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="20"/>
         <source>Arvonlisävero</source>
-        <translation type="unfinished"></translation>
+        <translation>Value Added Tax</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="26"/>
         <source>Verokauden pituus</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax period length</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="36"/>
         <source>Maksuperusteinen ALV</source>
-        <translation type="unfinished"></translation>
+        <translation>Cash-based VAT</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="107"/>
         <source>Tositteiden lukitseminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Locking of vouchers</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="113"/>
         <source>Salli tositteiden muokkaaminen alv-ilmoituksen antamisen jälkeen</source>
-        <translation type="unfinished"></translation>
+        <translation>Allow editing of vouchers after submitting VAT return</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="126"/>
         <source>Viitenumerot</source>
-        <translation type="unfinished"></translation>
+        <translation>Reference numbers</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="132"/>
         <source>Tuloverojen viite</source>
-        <translation type="unfinished"></translation>
+        <translation>Income tax reference</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="142"/>
         <source>VeroTuloViite</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax Income Reference</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="152"/>
         <source>Oma-aloitteisten verojen viite</source>
-        <translation type="unfinished"></translation>
+        <translation>Self-assessed taxes reference</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="68"/>
         <source>Arvonlisäveron kirjaus arvonlisäveroilmoituksen yhteydessä</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT recording in connection with VAT return</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="74"/>
         <source>Kirjaa aina Verovelat-tilille</source>
-        <translation type="unfinished"></translation>
+        <translation>Always record to Tax Liabilities account</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="84"/>
         <source>Kirjaa maksettavat Verovelat-tilille ja palautukset Verosaatavat-tilille</source>
-        <translation type="unfinished"></translation>
+        <translation>Record payables to Tax Liabilities account and refunds to Tax Receivables account</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="94"/>
         <source>Kirjaa Maksettava alv/Palautettava alv -tileille</source>
-        <translation type="unfinished"></translation>
+        <translation>Record to VAT Payable/VAT Refundable accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="218"/>
         <source>Verohallinnon varmenne</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax Administration certificate</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="45"/>
         <location filename="../maaritys/veromaaritys.ui" line="234"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="175"/>
         <source>Yhteystiedot veroja ilmoitettaessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact information for tax reporting</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="181"/>
         <source>Yhteyshenkilön nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact person&apos;s name</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="205"/>
         <source>Puhelinnumero</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="246"/>
         <source>Uusi varmenne</source>
-        <translation type="unfinished"></translation>
+        <translation>New certificate</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.ui" line="257"/>
         <source>Poista varmenne</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove certificate</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="34"/>
         <source>Kuukausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Month</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="35"/>
         <source>Neljännesvuosi</source>
-        <translation type="unfinished"></translation>
+        <translation>Quarter</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="36"/>
         <source>Vuosi</source>
-        <translation type="unfinished"></translation>
+        <translation>Year</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="142"/>
         <source>Varmenteen poistaminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Removing certificate</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="143"/>
         <source>Haluatko todella poistaa verohallinnon varmenteen käytöstä?</source>
-        <translation type="unfinished"></translation>
+        <translation>Do you really want to remove the tax administration certificate from use?</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="157"/>
         <source>Ei käytössä</source>
-        <translation type="unfinished"></translation>
+        <translation>Not in use</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="159"/>
         <source>Käytössä %1 alkaen</source>
-        <translation type="unfinished"></translation>
+        <translation>In use from %1</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="161"/>
         <source>%1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="168"/>
         <source>Tilikartta puutteellinen</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts incomplete</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="168"/>
         <source>Maksuperusteiseen arvonlisäveroon tarvittavat kohdentamattoman arvonlisäverovelan ja/tai arvonlisäverosaatavien tilit puuttuvat.
 Ottaaksesi maksuperusteisen arvonlisäveron käyttöön lisää tarvittavat tilit tilikarttaasi</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounts for unallocated VAT debt and/or VAT receivables required for cash-based VAT are missing.
+To enable cash-based VAT, add the necessary accounts to your chart of accounts</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="224"/>
         <source>Tositteiden muokkaaminen alv-ilmoituksen antamisen jälkeen</source>
-        <translation type="unfinished"></translation>
+        <translation>Editing vouchers after submitting VAT return</translation>
     </message>
     <message>
         <location filename="../maaritys/veromaaritys.cpp" line="225"/>
@@ -15462,7 +15625,11 @@ Ottaaksesi maksuperusteisen arvonlisäveron käyttöön lisää tarvittavat tili
 Olet vastuussa siitä, jos tositteiden muokkaaminen edellyttää uuden alv-ilmoituksen antamista.
 
 Huomioi Kirjanpitolan 2. luvun 7§ 2. mom. kielto kirjanpidon sisällön muokkaamisesta sen jälkeen kun kirjanpidosta viranomaiselle verotusta varten annettu ilmoitus on tehty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you really enabling the editing of vouchers after submitting the VAT return?
+
+You are responsible if editing the vouchers requires submitting a new VAT return.
+
+Please note the prohibition in Chapter 2, Section 7, Paragraph 2 of the Accounting Act on modifying the content of accounting after a tax-related report has been submitted to the authorities based on the accounting.</translation>
     </message>
 </context>
 <context>
@@ -15470,92 +15637,97 @@ Huomioi Kirjanpitolan 2. luvun 7§ 2. mom. kielto kirjanpidon sisällön muokkaa
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="52"/>
         <source>Varmennetta ei ole otettu käyttöön.</source>
-        <translation type="unfinished"></translation>
+        <translation>The certificate has not been activated.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="54"/>
         <source>Verohallinnon varmenne on noudettu %1.
 Varmenne ei välttämättä ole vielä käytettävissä</source>
-        <translation type="unfinished"></translation>
+        <translation>The tax administration certificate has been retrieved on %1.
+The certificate may not be available for use yet</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="56"/>
         <source>Verohallinnon varmenne on käytettävissä. 
 Varmenne noudettu %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>The tax administration certificate is available.
+Certificate retrieved on %1.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="58"/>
         <source>Tilitoimiston varmenne on käytettävissä</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting firm&apos;s certificate is available</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="61"/>
         <source>Varmenteen hakeminen on kesken.
 Hakeminen kestää noin minuutin.</source>
-        <translation type="unfinished"></translation>
+        <translation>Certificate retrieval is in progress.
+Retrieval takes about a minute.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="63"/>
         <source>Varmenteen uusiminen on käynnissä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Certificate renewal is in progress.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="65"/>
         <source>Varmenne on poistettu</source>
-        <translation type="unfinished"></translation>
+        <translation>The certificate has been removed</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="67"/>
         <source>Varmenteen hakeminen epäonnistui. 
 Varmenteen hakemisessa käytetyt tunnukset olivat virheellisiä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to retrieve certificate. 
+The credentials used to retrieve the certificate were incorrect.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="69"/>
         <source>Varmenteen hakeminen epäonnistui (Virhe %1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to retrieve certificate (Error %1)</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="80"/>
         <source>Tarkasta arvonlisäverovelvolliseksi rekisteröityminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Check VAT registration</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="82"/>
         <source>Virheellinen y-tunnus</source>
-        <translation type="unfinished"></translation>
+        <translation>Invalid business ID</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="84"/>
         <source>Verokausien hakeminen epäonnistui.</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to retrieve tax periods.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="89"/>
         <source>Varmenteelta puuttuu oikeudet verotietoihin</source>
-        <translation type="unfinished"></translation>
+        <translation>The certificate lacks permissions for tax information</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="91"/>
         <source>Verohallinnon varmenne on noudettu %1.
 Varmenne ei vielä ole käytettävissä.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax Administration certificate has been retrieved %1.
+The certificate is not yet available.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="93"/>
         <source>Varmenteessa on ongelma, eikä sillä voi antaa alv-ilmoitusta.</source>
-        <translation type="unfinished"></translation>
+        <translation>There is a problem with the certificate, and it cannot be used to submit a VAT return.</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="97"/>
         <source>Tilitoimistolta puuttuu Suomi.fi-valtuutus veroasioiden hoitamiseen</source>
-        <translation type="unfinished"></translation>
+        <translation>The accounting firm lacks Suomi.fi authorization to handle tax matters</translation>
     </message>
     <message>
         <location filename="../alv/verovarmennetila.cpp" line="100"/>
         <source>Arvonlisäverokausien hakeminen toimiston varmenteella epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to retrieve VAT periods using the office certificate</translation>
     </message>
 </context>
 <context>
@@ -15563,7 +15735,7 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../tools/vuosidelegaatti.cpp" line="14"/>
         <source> vuotta</source>
-        <translation type="unfinished"></translation>
+        <translation> years</translation>
     </message>
 </context>
 <context>
@@ -15571,22 +15743,22 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../rekisteri/yhdistakumppaniin.ui" line="14"/>
         <source>Rekisteriyhdistäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Register merging</translation>
     </message>
     <message>
         <location filename="../rekisteri/yhdistakumppaniin.ui" line="20"/>
         <source>Tällä toiminnolla voit yhdistää rekisterissä olevat kaksoiskappaleet. Valitse, mihin yhdistetään</source>
-        <translation type="unfinished"></translation>
+        <translation>With this function, you can merge duplicates in the register. Choose which one to merge into</translation>
     </message>
     <message>
         <location filename="../rekisteri/yhdistakumppaniin.ui" line="36"/>
         <source>Ynimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Company name</translation>
     </message>
     <message>
         <location filename="../rekisteri/yhdistakumppaniin.ui" line="46"/>
         <source>Näytä vain sopivimmat</source>
-        <translation type="unfinished"></translation>
+        <translation>Show only the most suitable</translation>
     </message>
 </context>
 <context>
@@ -15594,48 +15766,48 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Dialog</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="25"/>
         <source>Yhteystiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact information</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="37"/>
         <source>Katuosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Street address</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="44"/>
         <source>Postiosoite</source>
-        <translation type="unfinished"></translation>
+        <translation>Postal address</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="78"/>
         <location filename="../maaritys/yhteystiedot.ui" line="178"/>
         <source>Puhelin</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="95"/>
         <source>Sähköposti</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="112"/>
         <source>Kotisivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Homepage</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="129"/>
         <source>Kotipaikka</source>
-        <translation type="unfinished"></translation>
+        <translation>Domicile</translation>
     </message>
     <message>
         <location filename="../maaritys/yhteystiedot.ui" line="169"/>
         <source>Yhteystiedot veroa ilmoitettaessa</source>
-        <translation type="unfinished"></translation>
+        <translation>Contact information for tax purposes</translation>
     </message>
 </context>
 <context>
@@ -15643,117 +15815,117 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="25"/>
         <source>Kappale</source>
-        <translation type="unfinished"></translation>
+        <translation>Piece</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="26"/>
         <source>Pakkaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Package</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="28"/>
         <source>Kilogramma</source>
-        <translation type="unfinished"></translation>
+        <translation>Kilogram</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="29"/>
         <source>Litra</source>
-        <translation type="unfinished"></translation>
+        <translation>Liter</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="30"/>
         <source>Vuosi</source>
-        <translation type="unfinished"></translation>
+        <translation>Year</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="31"/>
         <source>Kuukausi</source>
-        <translation type="unfinished"></translation>
+        <translation>Month</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="27"/>
         <source>Henkilö</source>
-        <translation type="unfinished"></translation>
+        <translation>Person</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="32"/>
         <source>Päivä</source>
-        <translation type="unfinished"></translation>
+        <translation>Day</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="33"/>
         <source>Tunti</source>
-        <translation type="unfinished"></translation>
+        <translation>Hour</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="34"/>
         <source>Minuutti</source>
-        <translation type="unfinished"></translation>
+        <translation>Minute</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="35"/>
         <source>Tunti työtä</source>
-        <translation type="unfinished"></translation>
+        <translation>Hour of work</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="36"/>
         <source>Yksikkö työtä</source>
-        <translation type="unfinished"></translation>
+        <translation>Unit of work</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="37"/>
         <source>Laskutusyksikkö</source>
-        <translation type="unfinished"></translation>
+        <translation>Billing unit</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="38"/>
         <source>Työsuorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Work performance</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="39"/>
         <source>Metri</source>
-        <translation type="unfinished"></translation>
+        <translation>Meter</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="40"/>
         <source>Senttimetri</source>
-        <translation type="unfinished"></translation>
+        <translation>Centimeter</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="41"/>
         <source>Kilometri</source>
-        <translation type="unfinished"></translation>
+        <translation>Kilometer</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="42"/>
         <source>Kilowattitunti</source>
-        <translation type="unfinished"></translation>
+        <translation>Kilowatt-hour</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="43"/>
         <source>Neliömetri</source>
-        <translation type="unfinished"></translation>
+        <translation>Square meter</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="44"/>
         <source>Hehtaari</source>
-        <translation type="unfinished"></translation>
+        <translation>Hectare</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="45"/>
         <source>Kuutiometri</source>
-        <translation type="unfinished"></translation>
+        <translation>Cubic meter</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="46"/>
         <source>Osake</source>
-        <translation type="unfinished"></translation>
+        <translation>Share</translation>
     </message>
     <message>
         <location filename="../laskutus/yksikkomodel.cpp" line="47"/>
         <source>Sivu</source>
-        <translation type="unfinished"></translation>
+        <translation>Page</translation>
     </message>
 </context>
 <context>
@@ -15761,12 +15933,12 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../laskutus/laskudlg/yksittainenlaskudialogi.cpp" line="32"/>
         <source>Tallennusvirhe</source>
-        <translation type="unfinished"></translation>
+        <translation>Save error</translation>
     </message>
     <message>
         <location filename="../laskutus/laskudlg/yksittainenlaskudialogi.cpp" line="33"/>
         <source>Laskun tallennus epäonnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoice saving failed</translation>
     </message>
 </context>
 <context>
@@ -15774,12 +15946,12 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../lisaosat/yksityinenlisaosadialogi.ui" line="14"/>
         <source>Yksityinen lisäosa</source>
-        <translation type="unfinished"></translation>
+        <translation>Private add-on</translation>
     </message>
     <message>
         <location filename="../lisaosat/yksityinenlisaosadialogi.ui" line="24"/>
         <source>Käyttöön otettavan lisäosan tunniste:</source>
-        <translation type="unfinished"></translation>
+        <translation>Identifier of the add-on to be activated:</translation>
     </message>
 </context>
 <context>
@@ -15788,47 +15960,47 @@ Varmenne ei vielä ole käytettävissä.</source>
         <location filename="../arkisto/yksityistilienpaattaja.ui" line="14"/>
         <location filename="../arkisto/yksityistilienpaattaja.cpp" line="103"/>
         <source>Yksityistilien päättäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Closing private accounts</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.ui" line="23"/>
         <source>Päätä yksityistilit peruspääomaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Close private accounts to basic capital</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.ui" line="33"/>
         <source>Päätä tilikauden tulos peruspääomaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Close financial year result to basic capital</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.ui" line="45"/>
         <source>Peruspääoman tili</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic capital account</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.cpp" line="48"/>
         <source>Yksityistilien %1 päättäminen</source>
-        <translation type="unfinished"></translation>
+        <translation>Closing private accounts %1</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.cpp" line="76"/>
         <source>Tilikauden %1 tuloksen päättäminen peruspääomaan</source>
-        <translation type="unfinished"></translation>
+        <translation>Closing financial year %1 result to basic capital</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.cpp" line="112"/>
         <source>Yksityistilit tilikaudella</source>
-        <translation type="unfinished"></translation>
+        <translation>Private accounts in the financial year</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.cpp" line="130"/>
         <source>Yhteensä</source>
-        <translation type="unfinished"></translation>
+        <translation>Total</translation>
     </message>
     <message>
         <location filename="../arkisto/yksityistilienpaattaja.cpp" line="137"/>
         <source>Tilikauden tulos</source>
-        <translation type="unfinished"></translation>
+        <translation>Financial year result</translation>
     </message>
 </context>
 <context>
@@ -15836,12 +16008,12 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../onniwidget.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="../onniwidget.ui" line="59"/>
         <source>Toiminto onnistui</source>
-        <translation type="unfinished"></translation>
+        <translation>Operation successful</translation>
     </message>
 </context>
 <context>
@@ -15849,158 +16021,158 @@ Varmenne ei vielä ole käytettävissä.</source>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="14"/>
         <source>Tilin muokkaus</source>
-        <translation type="unfinished"></translation>
+        <translation>Account editing</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="28"/>
         <source>Perustiedot</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic information</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="36"/>
         <source>Kuuluu otsikolle</source>
-        <translation type="unfinished"></translation>
+        <translation>Belongs to header</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="43"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="50"/>
         <source>Numero</source>
-        <translation type="unfinished"></translation>
+        <translation>Number</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="63"/>
         <source>Nimi</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="95"/>
         <source>Tilityyppi</source>
-        <translation type="unfinished"></translation>
+        <translation>Account type</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="108"/>
         <source>Tilikartan laajuus</source>
-        <translation type="unfinished"></translation>
+        <translation>Chart of accounts scope</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="121"/>
         <source>Vastatili</source>
-        <translation type="unfinished"></translation>
+        <translation>Contra account</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="159"/>
         <source>FI00000000000000</source>
-        <translation type="unfinished"></translation>
+        <translation>FI00000000000000</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="131"/>
         <source>Kohdennus</source>
-        <translation type="unfinished"></translation>
+        <translation>Allocation</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="143"/>
         <source>Pankkitili</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank account</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="149"/>
         <source>IBAN</source>
-        <translation type="unfinished"></translation>
+        <translation>IBAN</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="166"/>
         <source>BIC</source>
-        <translation type="unfinished"></translation>
+        <translation>BIC</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="173"/>
         <source>Pankki</source>
-        <translation type="unfinished"></translation>
+        <translation>Bank</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="211"/>
         <source>Erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Specification</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="217"/>
         <source>Tase-erittely</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance sheet specification</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="223"/>
         <source>Täysi erittely tase-erillä</source>
-        <translation type="unfinished"></translation>
+        <translation>Full specification with balance sheet items</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="230"/>
         <source>Tase-erien luettelo</source>
-        <translation type="unfinished"></translation>
+        <translation>List of balance sheet items</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="237"/>
         <source>Lisäykset ja vähennykset</source>
-        <translation type="unfinished"></translation>
+        <translation>Additions and deductions</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="244"/>
         <source>Saldo</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="275"/>
         <source>Poisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Depreciation</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="281"/>
         <source>Poistoaika</source>
-        <translation type="unfinished"></translation>
+        <translation>Depreciation period</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="291"/>
         <source> vuotta</source>
-        <translation type="unfinished"></translation>
+        <translation> years</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="301"/>
         <source>Menojäännöspoisto</source>
-        <translation type="unfinished"></translation>
+        <translation>Declining balance depreciation</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="311"/>
         <location filename="../maaritys/tilinmuokkaus.ui" line="377"/>
         <source> %</source>
-        <translation type="unfinished"></translation>
+        <translation> %</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="318"/>
         <source>Poistotili</source>
-        <translation type="unfinished"></translation>
+        <translation>Depreciation account</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="349"/>
         <source>ALV</source>
-        <translation type="unfinished"></translation>
+        <translation>VAT</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="357"/>
         <source>Verolaji</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax type</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="370"/>
         <source>Veroprosentti</source>
-        <translation type="unfinished"></translation>
+        <translation>Tax percentage</translation>
     </message>
     <message>
         <location filename="../maaritys/tilinmuokkaus.ui" line="404"/>
         <source>Kirjausohje</source>
-        <translation type="unfinished"></translation>
+        <translation>Booking instructions</translation>
     </message>
 </context>
 </TS>

--- a/kitsas/tr/tr.qrc
+++ b/kitsas/tr/tr.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/tr">
         <file>tulkki.json</file>
         <file>kitsas_sv.qm</file>
+        <file>kitsas_en.qm</file>
         <file>qtbase_fi.qm</file>
         <file>qtbase_sv.qm</file>
     </qresource>

--- a/kitsas/uusikirjanpito/uusitilikartta.ui
+++ b/kitsas/uusikirjanpito/uusitilikartta.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Valitse käytettävä tilikartta kirjanpidosi mukaisesti. Voit myöhemmin muokata käyttöön otettavaa mallitilikarttaa ja raporttipohjia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Valitse käytettävä tilikartta kirjanpitosi mukaisesti. Voit myöhemmin muokata käyttöön otettavaa mallitilikarttaa ja raporttipohjia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
Small commit to add English translations to kitsas_en.ts.
I'm not an accountant, and didn't check correctness of all the translations.
Also fix a typo in uusitilikartta.ui and add kitsas_en.ts to tr.qrc.
Partially fixes #1285.
More work is needed for full English translation of the app.