### PR TITLE
CSV import: fix column-type classification and Viite dropdown (#1399, #1400)

### DIFF
--- a/kitsas/tuonti/csvtuonti.cpp
+++ b/kitsas/tuonti/csvtuonti.cpp
@@ -786,6 +786,8 @@ int CsvTuonti::tuoListaan(const QByteArray &data)
                     muodot_[i] = RAHA;
                 else if( (muodot_[i] == LUKU && muoto == VIITE ) || (muodot_[i] == VIITE && muoto == LUKU) )
                     muodot_[i] = LUKU;
+                else if( muodot_[i] == LUKU && muoto == ALLESATA)
+                    muodot_[i] = LUKU;
                 else
                     muodot_[i] = TEKSTI;
             }

--- a/kitsas/tuonti/tuontisarakedelegaatti.cpp
+++ b/kitsas/tuonti/tuontisarakedelegaatti.cpp
@@ -48,7 +48,11 @@ QWidget *TuontiSarakeDelegaatti::createEditor(QWidget *parent, const QStyleOptio
 
     comboon(combo, CsvTuonti::EITUODA);
 
-   if( !tuokirjauksia_ && ( tyyppi == CsvTuonti::VIITE || nykyinen == CsvTuonti::VIITE)) {
+   if( !tuokirjauksia_ && ( tyyppi == CsvTuonti::VIITE ||
+                            tyyppi == CsvTuonti::RAHA ||
+                            tyyppi == CsvTuonti::LUKU ||
+                            tyyppi == CsvTuonti::ALLESATA ||
+                            nykyinen == CsvTuonti::VIITENRO)) {
         comboon(combo, CsvTuonti::VIITENRO);
     }
 


### PR DESCRIPTION
Fixes two long-standing CSV import bugs.

## #1400 — Incorrect interpretation in CSV when decimals are missing from euro amount

`CsvTuonti::tuoListaan()` infers each column's `Sarakemuoto` by merging the per-row classifications. The merge already handled `ALLESATA + LUKU → LUKU`, but the symmetric case `LUKU + ALLESATA` fell into the default branch and turned the column into `TEKSTI`. So whenever the first money cell was `>= 100` and a later one was `< 100` (e.g. `100` and `80` in the attached test file), the column was classified as text, and `paivitaOletukset()` could no longer default it to `RAHAMAARA`.

Added the missing merge case so the column stays `LUKU`.

## #1399 — Reference info misinterpreted as Rahamäärä

When a Viite column contains long digit strings with internal spaces (the attached test file has `2 000 805 730 010 100 000`) whose checksum does not validate as a Finnish reference number, classification falls through to `rahaRe` (digits-only after whitespace removal) and the column gets `muoto = RAHA`.

In tiliote mode `TuontiSarakeDelegaatti::createEditor()` then offers only `RAHAMAARA` for a `RAHA/LUKU/ALLESATA` column, so the user cannot override the field type back to Viitenumero.

Added `VIITENRO` to the dropdown for those `muoto` values in tiliote mode. Also corrected an existing comparison in the same predicate: `nykyinen == CsvTuonti::VIITE` compared the current `Tuominen` selection (max value 20) against `Sarakemuoto::VIITE` (22), so it could never be true — changed to `Tuominen::VIITENRO`.

## Verification

Both bugs and both fixes were reproduced with a standalone Python script that re-implements `tuoListaan()`'s classification logic and simulates the delegate's dropdown predicate. The C++ patches mirror the verified Python logic exactly.

The CSV test files attached to the original issues can be used as test data:
- #1400: https://github.com/user-attachments/files/17282958/test.csv
- #1399: https://github.com/user-attachments/files/17274214/test.csv