### PR TITLE
Lisätty tiliotetuontiin tuki Nordean CSV-muodon VVVV/KK/PP päivämäärämuodolle

### DIFF
--- a/kitsas/tuonti/csvtuonti.cpp
+++ b/kitsas/tuonti/csvtuonti.cpp
@@ -331,6 +331,8 @@ QVariantMap CsvTuonti::tiliote()
                     pvm = QDate::fromString(tieto, "d.M.yyyy");
                 else if( muodot_.at(c) == ISOPVM )
                     pvm = QDate::fromString(tieto, Qt::ISODate);
+                else if( muodot_.at(c) == NDEAPVM )
+                    pvm = QDate::fromString(tieto, "yyyy/MM/dd");
                 else
                     pvm = QDate::fromString(tieto, Qt::RFC2822Date);
                 rivi.insert("pvm", pvm);
@@ -620,7 +622,7 @@ void CsvTuonti::paivitaOletukset()
             QString otsikko = otsikot.at(i).toLower() ;
             Sarakemuoto muoto = muodot_.at(i);
 
-            if( (muoto == SUOMIPVM || muoto == ISOPVM || muoto == USPVM)  && !pvmkaytetty )
+            if( (muoto == SUOMIPVM || muoto == ISOPVM || muoto == USPVM || muoto == NDEAPVM)  && !pvmkaytetty )
             {
                 ui->tuontiTable->item(i,2)->setData(Qt::EditRole, PAIVAMAARA);
                 pvmkaytetty = true;
@@ -669,7 +671,7 @@ void CsvTuonti::paivitaOletukset()
             const QString& otsikko = otsikot.at(i);
             Sarakemuoto muoto = muodot_.at(i);
 
-            if( (muoto == SUOMIPVM || muoto==ISOPVM || muoto == USPVM) && !pvmkaytetty)
+            if( (muoto == SUOMIPVM || muoto==ISOPVM || muoto == USPVM || muoto == NDEAPVM) && !pvmkaytetty)
             {
                 ui->tuontiTable->item(i,2)->setData(Qt::EditRole, PAIVAMAARA);
                 pvmkaytetty = true;

--- a/unittest/apptest.pri
+++ b/unittest/apptest.pri
@@ -8,6 +8,8 @@ QT += printsupport
 QT += network
 QT += svg
 QT += xml
+QT += pdf
+QT += pdfwidgets
 
 LIBS += -lpoppler-qt5
 LIBS += -lpoppler


### PR DESCRIPTION
Tuki oli jo olemassa jotain muuta aineistotuontia varten, mutta CSV-tapauksesssa sitä ei aiemmin käytetty.

Minulla ei myöskään mennyt buildi läpi ilman noita pdf-rivejä apptest.pri:ssä.